### PR TITLE
Add undo function for language proficiency migration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,3 @@
 omit =
     ; Don't complain about Django's manage.py file
     manage.py
-    
-    ; Don't complain about language proficiency migration file. It's not possible to test it.
-    0013_languageproficiency_alter_profile_language.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,7 @@
 [run]
 omit =
+    ; Don't complain about Django's manage.py file
     manage.py
-    schema.py
+    
+    ; Don't complain about language proficiency migration file. It's not possible to test it.
+    0013_languageproficiency_alter_profile_language.py

--- a/users/migrations/0013_languageproficiency_alter_profile_language.py
+++ b/users/migrations/0013_languageproficiency_alter_profile_language.py
@@ -3,7 +3,7 @@
 from django.db import migrations, models
 import django.db.models.deletion
 
-def create_language_proficiency(apps, schema_editor):
+def create_language_proficiency(apps, schema_editor): # pragma: no cover
     for profile in apps.get_model('users', 'Profile').objects.all():
         for language in profile.language.all():
             apps.get_model('users', 'LanguageProficiency').objects.create(
@@ -12,7 +12,7 @@ def create_language_proficiency(apps, schema_editor):
                 proficiency=''
             )
 
-def undo_create_language_proficiency(apps, schema_editor):
+def undo_create_language_proficiency(apps, schema_editor): # pragma: no cover
     for proficiency in apps.get_model('users', 'LanguageProficiency').objects.all():
         proficiency.profile.language.add(proficiency.language)
         proficiency.delete()

--- a/users/migrations/0013_languageproficiency_alter_profile_language.py
+++ b/users/migrations/0013_languageproficiency_alter_profile_language.py
@@ -12,6 +12,11 @@ def create_language_proficiency(apps, schema_editor):
                 proficiency=''
             )
 
+def undo_create_language_proficiency(apps, schema_editor):
+    for proficiency in apps.get_model('users', 'LanguageProficiency').objects.all():
+        proficiency.profile.language.add(proficiency.language)
+        proficiency.delete()
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -31,7 +36,7 @@ class Migration(migrations.Migration):
                 'unique_together': {('profile', 'language')},
             },
         ),
-        migrations.RunPython(create_language_proficiency),
+        migrations.RunPython(create_language_proficiency, undo_create_language_proficiency),
         migrations.RemoveField(
             model_name='profile',
             name='language',


### PR DESCRIPTION
This pull request introduces a new method to undo the creation of language proficiency entries in the `users` app migration script. Additionally, it modifies the migration class to include this new method as the reverse operation.

Key changes include:

* Added `undo_create_language_proficiency` method to reverse the creation of language proficiency entries. (`users/migrations/0013_languageproficiency_alter_profile_language.py`)
* Updated the `Migration` class to use `undo_create_language_proficiency` as the reverse operation for `create_language_proficiency`. (`users/migrations/0013_languageproficiency_alter_profile_language.py`)