### PR TITLE
Add middleware to handle database connection errors gracefully

### DIFF
--- a/CapX/middlewares.py
+++ b/CapX/middlewares.py
@@ -1,0 +1,21 @@
+from django.db.utils import OperationalError
+from django.http import JsonResponse
+
+class DatabaseErrorMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        try:
+            return self.get_response(request)
+        except OperationalError as e:
+            error_message = str(e)
+            if "Can't connect to MySQL server" in error_message:
+                return JsonResponse(
+                    {
+                        "detail": "Toolforge' database is not available at the moment. Please try again later.",
+                        "message": error_message
+                    },
+                    status=503
+                )
+            raise

--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -53,6 +53,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
+    'CapX.middlewares.DatabaseErrorMiddleware',
 ]
 
 ROOT_URLCONF = 'CapX.urls'

--- a/CapX/tests/test_middlewares.py
+++ b/CapX/tests/test_middlewares.py
@@ -1,0 +1,66 @@
+from django.test import TestCase, RequestFactory
+from django.http import JsonResponse
+from django.db.utils import OperationalError
+from ..middlewares import DatabaseErrorMiddleware
+import json
+
+class DatabaseErrorMiddlewareTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.get_response = lambda request: JsonResponse({"detail": "success"})
+        self.middleware = DatabaseErrorMiddleware(self.get_response)
+
+    def test_middleware_handles_operational_error(self):
+        request = self.factory.get('/')
+        def error_response(request):
+            raise OperationalError("Can't connect to MySQL server")
+
+        middleware = DatabaseErrorMiddleware(error_response)
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(json.loads(response.content), {
+            "detail": "Toolforge' database is not available at the moment. Please try again later.",
+            "message": "Can't connect to MySQL server"
+        })
+
+    def test_middleware_allows_normal_response(self):
+        request = self.factory.get('/')
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {"detail": "success"})
+
+    def test_middleware_handles_other_operational_error(self):
+        request = self.factory.get('/')
+
+        def error_response(request):
+            raise OperationalError("Some other error")
+
+        middleware = DatabaseErrorMiddleware(error_response)
+        with self.assertRaises(OperationalError):
+            middleware(request)
+
+    def test_middleware_handles_other_exceptions(self):
+        request = self.factory.get('/')
+
+        def error_response(request):
+            raise ValueError("Some other error")
+
+        middleware = DatabaseErrorMiddleware(error_response)
+        with self.assertRaises(ValueError):
+            middleware(request)
+
+    def test_middleware_with_post_request(self):
+        request = self.factory.post('/')
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {"detail": "success"})
+
+    def test_middleware_with_put_request(self):
+        request = self.factory.put('/')
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {"detail": "success"})


### PR DESCRIPTION
This pull request introduces a new middleware to handle database connection errors and integrates it into the Django settings. The most important changes include the addition of the `DatabaseErrorMiddleware` class and its inclusion in the middleware settings.

Middleware addition:

* [`CapX/middlewares.py`](diffhunk://#diff-bcf17ed79b57a74d7592e47de85d0ad1ebcf013b4b82d3caca4778a065f4719cR1-R21): Added a new `DatabaseErrorMiddleware` class to handle `OperationalError` exceptions and return a JSON response with a 503 status code if the MySQL server is not available.

Settings modification:

* [`CapX/settings.py`](diffhunk://#diff-6f9b02506e9090171d696773b3cca52c9ee9c89a1cd88bb5c4a4c97b5deee942R56): Included the `DatabaseErrorMiddleware` in the middleware list to ensure it is used in the application.