### PR TITLE
Profile and CustomUser ID mathes

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -181,6 +181,20 @@ class Profile(models.Model):
         help_text="json"
     )
 
+    def save(self, *args, **kwargs):
+        """
+        Overrides the save method to set the primary key (pk) of the instance to the
+        primary key of the associated user to ensure that both the user and profile
+        have the same primary key.
+
+        Args:
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+        """
+        if not self.pk and self.user:
+            self.pk = self.user.pk
+        super().save(*args, **kwargs)
+
     def __str__(self):
         return self.user.username
 

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -2,8 +2,9 @@ import secrets
 from django.test import TestCase
 from django.db import IntegrityError
 from django.core.exceptions import ValidationError
+from django.db.models.signals import post_save
 from ..models import Territory, Language, WikimediaProject, Organization, CustomUser, \
-    Profile, LanguageProficiency, Avatar
+    Profile, LanguageProficiency, Avatar, create_user_profile
 
 
 class TerritoryModelTest(TestCase):
@@ -103,6 +104,32 @@ class CustomUserModelTest(TestCase):
                 email="another@example.com",
                 password=str(secrets.randbits(16)),
             )
+
+    def test_pk_mismatch(self):
+        # Temporarily disconnect the signal
+        post_save.disconnect(create_user_profile, sender=CustomUser)
+        
+        CustomUser.objects.create_user(
+            username="Anthony",
+            email="",
+            password=str(secrets.randbits(16)),
+        )
+        user = CustomUser.objects.get(username="Anthony")
+        self.assertFalse(hasattr(user, 'profile'))
+        
+        # Reconnect the signal
+        post_save.connect(create_user_profile, sender=CustomUser)
+
+        CustomUser.objects.create_user(
+            username="Anthonie",
+            email="",
+            password=str(secrets.randbits(16)),
+        )
+        user = CustomUser.objects.get(username="Anthonie")
+        self.assertTrue(hasattr(user, 'profile'))
+        
+        # Assert that both profile and user have the same pk
+        self.assertEqual(user.pk, user.profile.pk)
 
 
 class ProfileModelTest(TestCase):


### PR DESCRIPTION
This pull request includes changes to the `Profile` model in `users/models.py` and corresponding tests in `users/tests/test_models.py`. The changes ensure that the primary key of the `Profile` instance matches the primary key of the associated `CustomUser`.

Changes to the `Profile` model:

* [`users/models.py`](diffhunk://#diff-9d9b19f5976005b432bc617914003383689329533cd1dd7045352a02ad07ac7bR184-R197): Added an override for the `save` method in the `Profile` model to set the primary key of the instance to the primary key of the associated user. This ensures that both the user and profile have the same primary key.

Updates to tests:

* [`users/tests/test_models.py`](diffhunk://#diff-c27a055745af6a458f5452d4581f872c2917ef5a7447411ba13fa573925c01f0R5-R7): Imported `post_save` signal to handle the creation of user profiles in tests.
* [`users/tests/test_models.py`](diffhunk://#diff-c27a055745af6a458f5452d4581f872c2917ef5a7447411ba13fa573925c01f0R108-R133): Added a new test method `test_pk_mismatch` in `ProfileModelTest` to verify that the primary key of the `Profile` matches the primary key of the associated `CustomUser`. This includes temporarily disconnecting and reconnecting the `create_user_profile` signal to test the primary key assignment.