### PR TITLE
Add pagination settings to REST framework configuration

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -155,6 +155,8 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_METADATA_CLASS': 'CapX.metadata.CustomMetadata',
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 50,
 }
 REST_AUTH_SERIALIZERS = {
     "TOKEN_SERIALIZER": "users.serializers.KnoxSerializer",

--- a/bugs/tests/test_views.py
+++ b/bugs/tests/test_views.py
@@ -109,7 +109,7 @@ class AttachmentViewSetTestCase(APITestCase):
     def test_attachment_list(self):
         response = self.client.get('/attachment/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data['results']), 1)
 
     def test_attachment_list_staff(self):
         self.user.is_staff = True

--- a/message/tests/test_views.py
+++ b/message/tests/test_views.py
@@ -23,8 +23,8 @@ class MessageViewTest(TestCase):
         )
         response = self.client.get('/messages/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['message'], 'Sample message')
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['message'], 'Sample message')
 
     @patch('message.models.MessageService.send_message', return_value=None)
     def test_create_message(self, mock_send_message):
@@ -106,8 +106,8 @@ class MessageViewTest(TestCase):
         self.client.force_authenticate(user=self.staff_user)
         response = self.client.get('/messages/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['message'], 'Sample message')
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['message'], 'Sample message')
 
     @patch('message.models.MessageService.send_message', return_value=None)
     def test_create_message_as_another_user(self, mock_send_message):

--- a/orgs/tests/test_views.py
+++ b/orgs/tests/test_views.py
@@ -65,7 +65,7 @@ class OrganizationViewSetTestCase(APITestCase):
         )
         organization.territory.set([Territory.objects.get(pk=1)])
         response = self.client.get('/organizations/')
-        self.assertEqual(len(response.data), 0)
+        self.assertEqual(len(response.data['results']), 0)
 
         Organization.objects.create(
             display_name='New Organization 2',
@@ -75,7 +75,7 @@ class OrganizationViewSetTestCase(APITestCase):
         organization.territory.set([Territory.objects.get(pk=1)])
         organization.managers.set([self.user])
         response = self.client.get('/organizations/')
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data['results']), 1)
 
 
     def test_list_orgs_staff(self):
@@ -83,7 +83,7 @@ class OrganizationViewSetTestCase(APITestCase):
         self.client.force_authenticate(self.user)
         response = self.client.get('/organizations/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 0)
+        self.assertEqual(len(response.data['results']), 0)
 
         org_data = {
             'display_name': 'New Organization',
@@ -93,7 +93,7 @@ class OrganizationViewSetTestCase(APITestCase):
         }
         self.client.post('/organizations/', org_data)
         response = self.client.get('/organizations/')
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data['results']), 1)
 
     def test_retrieve_org(self):
         self.client.force_authenticate(self.user)
@@ -209,7 +209,7 @@ class OrganizationViewSetTestCase(APITestCase):
 
         TagDiff.objects.create(tag='Tag 1')
         response = self.client.get('/tag_diff/')
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data['results']), 1)
 
     def test_create_tagdiff(self):
         self.client.force_authenticate(self.user)

--- a/skills/tests/test_views.py
+++ b/skills/tests/test_views.py
@@ -22,7 +22,7 @@ class SkillViewSetTestCase(TestCase):
         response = self.client.get('/skill/')
         skills = Skill.objects.all()
         serializer = SkillSerializer(skills, many=True)
-        self.assertEqual(response.data, serializer.data)
+        self.assertEqual(response.data['results'], serializer.data)
 
     def test_get_skill_detail(self):
         response = self.client.get('/skill/1/')

--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -24,7 +24,7 @@ class ProfileViewSetTestCase(TestCase):
 
         profiles = Profile.objects.all()
         serializer = ProfileSerializer(profiles, many=True)
-        self.assertEqual(response.data, serializer.data)
+        self.assertEqual(response.data['results'], serializer.data)
 
     def test_get_profile_detail(self):
         response = self.client.get('/profile/' + str(self.user.pk) + '/')
@@ -112,7 +112,7 @@ class ProfileViewSetTestCase(TestCase):
 
         profiles = Profile.objects.all()
         serializer = ProfileSerializer(profiles, many=True)
-        self.assertEqual(response.data, serializer.data)
+        self.assertEqual(response.data['results'], serializer.data)
 
     def test_update_language_proficiency(self):
         language = Language.objects.create(language_name="Spanish", language_code="es")


### PR DESCRIPTION
This pull request includes a change to the `CapX/settings.py` file to add a default pagination class and set a default page size for the API. 

Configuration updates:

* [`CapX/settings.py`](diffhunk://#diff-6f9b02506e9090171d696773b3cca52c9ee9c89a1cd88bb5c4a4c97b5deee942R158-R159): Added `DEFAULT_PAGINATION_CLASS` with `rest_framework.pagination.LimitOffsetPagination` and set `PAGE_SIZE` to 50.