### PR TITLE
Add filtering capabilities for Users and Organizations

### DIFF
--- a/orgs/views.py
+++ b/orgs/views.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 from .models import Organization, OrganizationType, TagDiff, Document
 from .serializers import OrganizationSerializer, OrganizationTypeSerializer, TagDiffSerializer, DocumentSerializer
 from users.models import CustomUser as User, Territory
+from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
 
 @extend_schema_view(
@@ -22,6 +23,18 @@ from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiPara
 class OrganizationViewSet(viewsets.ModelViewSet):
     queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = [
+        'display_name',
+        'acronym',
+        'type',
+        'territory',
+        'managers',
+        'known_capacities',
+        'available_capacities',
+        'wanted_capacities',
+    ]
+
 
     def get_queryset(self):
         user = self.request.user

--- a/users/views.py
+++ b/users/views.py
@@ -7,6 +7,7 @@ from projects.models import Project
 from rest_framework import status, viewsets, filters
 from rest_framework.response import Response
 from django.shortcuts import get_object_or_404
+from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter, OpenApiTypes, OpenApiExample, OpenApiResponse
 
 
@@ -20,19 +21,21 @@ from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiPara
         description='This endpoint retrieves a user by their ID.',
     ),
 )
-class UsersViewSet(viewsets.ModelViewSet):
+class UsersViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ProfileSerializer
     queryset = Profile.objects.all()
-    filter_backends = [filters.SearchFilter]
-    search_fields = ['user__username', 'user__email', 'display_name', 'about']
-    http_method_names = ['get', 'head', 'options']
-
-    def get_queryset(self):
-        queryset = Profile.objects.all()
-        username = self.request.query_params.get('username', None)
-        if username is not None:
-            queryset = queryset.filter(user__username=username)
-        return queryset
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = [
+        'user__username',
+        'about',
+        'territory',
+        'wikimedia_project',
+        'affiliation',
+        'languageproficiency__language',
+        'skills_known',
+        'skills_available',
+        'skills_wanted'
+    ]
 
 @extend_schema_view(
     list=extend_schema(


### PR DESCRIPTION
This pull request includes changes to enhance filtering capabilities in the `OrganizationViewSet` and `UsersViewSet` classes by integrating the `DjangoFilterBackend` and adding filter fields. Additionally, it modifies the `UsersViewSet` to be read-only.

Enhancements to filtering capabilities:

* [`orgs/views.py`](diffhunk://#diff-6df9e3f87ceab9a2502dbea3a346fd86784ab096337f0530980ff8cdcd4229bbR6): Added `DjangoFilterBackend` to the `OrganizationViewSet` and defined filter fields for various attributes such as `display_name`, `acronym`, `type`, `territory`, `managers`, and capacities. [[1]](diffhunk://#diff-6df9e3f87ceab9a2502dbea3a346fd86784ab096337f0530980ff8cdcd4229bbR6) [[2]](diffhunk://#diff-6df9e3f87ceab9a2502dbea3a346fd86784ab096337f0530980ff8cdcd4229bbR26-R37)
* [`users/views.py`](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47R10): Added `DjangoFilterBackend` to the `UsersViewSet` and defined filter fields for attributes including `user__username`, `about`, `territory`, `wikimedia_project`, `affiliation`, `languageproficiency__language`, and skills. [[1]](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47R10) [[2]](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47L23-R38)

Modification to `UsersViewSet`:

* [`users/views.py`](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47L23-R38): Changed `UsersViewSet` from `ModelViewSet` to `ReadOnlyModelViewSet` to restrict it to read-only operations.