### PR TITLE
Add filtering options for user skills in UsersViewSet

### DIFF
--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -499,4 +499,66 @@ class UsersByTagTestCase(TestCase):
                 'profile_image': profile['profile_image']
             } for profile in serializer_data
         ]
-        self.assertEqual(response_data, simplified_serializer_data)    
+        self.assertEqual(response_data, simplified_serializer_data)
+
+class UsersFilterTestCase(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(username='test', password=str(secrets.randbits(16)))
+        self.client = APIClient()
+        self.client.force_authenticate(self.user)
+
+    def test_get_queryset_has_skills_known_true(self):
+        skill = Skill.objects.create(skill_wikidata_item="Q123456789")
+        profile = Profile.objects.get(user=self.user)
+        profile.skills_known.add(skill)
+
+        response = self.client.get('/users/', {'has_skills_known': 'true'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+
+    def test_get_queryset_has_skills_known_false(self):
+        response = self.client.get('/users/', {'has_skills_known': 'false'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+
+    def test_get_queryset_has_skills_available_true(self):
+        skill = Skill.objects.create(skill_wikidata_item="Q123456789")
+        profile = Profile.objects.get(user=self.user)
+        profile.skills_available.add(skill)
+
+        response = self.client.get('/users/', {'has_skills_available': 'true'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+
+    def test_get_queryset_has_skills_available_false(self):
+        response = self.client.get('/users/', {'has_skills_available': 'false'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+
+    def test_get_queryset_has_skills_wanted_true(self):
+        skill = Skill.objects.create(skill_wikidata_item="Q123456789")
+        profile = Profile.objects.get(user=self.user)
+        profile.skills_wanted.add(skill)
+
+        response = self.client.get('/users/', {'has_skills_wanted': 'true'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+
+    def test_get_queryset_has_skills_wanted_false(self):
+        response = self.client.get('/users/', {'has_skills_wanted': 'false'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+
+    def test_get_queryset_has_any_skills_true(self):
+        skill = Skill.objects.create(skill_wikidata_item="Q123456789")
+        profile = Profile.objects.get(user=self.user)
+        profile.skills_known.add(skill)
+
+        response = self.client.get('/users/', {'has_any_skills': 'true'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+
+    def test_get_queryset_has_any_skills_false(self):
+        response = self.client.get('/users/', {'has_any_skills': 'false'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)

--- a/users/views.py
+++ b/users/views.py
@@ -6,6 +6,7 @@ from events.models import Events
 from projects.models import Project
 from rest_framework import status, viewsets, filters
 from rest_framework.response import Response
+from django.db import models
 from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter, OpenApiTypes, OpenApiExample, OpenApiResponse

--- a/users/views.py
+++ b/users/views.py
@@ -50,7 +50,7 @@ from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiPara
 class UsersViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ProfileSerializer
     queryset = Profile.objects.all()
-    filter_backends = [DjangoFilterBackend, filters.SearchFilter]
+    filter_backends = [DjangoFilterBackend]
     filterset_fields = [
         'user__username',
         'about',

--- a/users/views.py
+++ b/users/views.py
@@ -15,6 +15,32 @@ from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiPara
     list=extend_schema(
         summary='List all users.',
         description='This endpoint lists all users.',
+        parameters=[
+            OpenApiParameter(
+                name='has_skills_known',
+                description='Filter users by whether they have known skills.',
+                required=False,
+                type=OpenApiTypes.BOOL,
+            ),
+            OpenApiParameter(
+                name='has_skills_available',
+                description='Filter users by whether they have available skills.',
+                required=False,
+                type=OpenApiTypes.BOOL,
+            ),
+            OpenApiParameter(
+                name='has_skills_wanted',
+                description='Filter users by whether they have wanted skills.',
+                required=False,
+                type=OpenApiTypes.BOOL,
+            ),
+            OpenApiParameter(
+                name='has_any_skills',
+                description='Filter users by whether they have any skills.',
+                required=False,
+                type=OpenApiTypes.BOOL,
+            ),
+        ],
     ),
     retrieve=extend_schema(
         summary='Retrieve a user by ID.',
@@ -24,7 +50,7 @@ from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiPara
 class UsersViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ProfileSerializer
     queryset = Profile.objects.all()
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter]
     filterset_fields = [
         'user__username',
         'about',
@@ -36,6 +62,47 @@ class UsersViewSet(viewsets.ReadOnlyModelViewSet):
         'skills_available',
         'skills_wanted'
     ]
+
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        has_skills_known = self.request.query_params.get('has_skills_known')
+        has_skills_available = self.request.query_params.get('has_skills_available')
+        has_skills_wanted = self.request.query_params.get('has_skills_wanted')
+
+        if has_skills_known is not None:
+            if has_skills_known.lower() == 'true':
+                queryset = queryset.filter(skills_known__isnull=False).distinct()
+            elif has_skills_known.lower() == 'false':
+                queryset = queryset.filter(skills_known__isnull=True).distinct()
+
+        if has_skills_available is not None:
+            if has_skills_available.lower() == 'true':
+                queryset = queryset.filter(skills_available__isnull=False).distinct()
+            elif has_skills_available.lower() == 'false':
+                queryset = queryset.filter(skills_available__isnull=True).distinct()
+
+        if has_skills_wanted is not None:
+            if has_skills_wanted.lower() == 'true':
+                queryset = queryset.filter(skills_wanted__isnull=False).distinct()
+            elif has_skills_wanted.lower() == 'false':
+                queryset = queryset.filter(skills_wanted__isnull=True).distinct()
+
+        if has_any_skills is not None:
+            if has_any_skills.lower() == 'true':
+                queryset = queryset.filter(
+                    models.Q(skills_known__isnull=False) |
+                    models.Q(skills_available__isnull=False) |
+                    models.Q(skills_wanted__isnull=False)
+                ).distinct()
+            elif has_any_skills.lower() == 'false':
+                queryset = queryset.filter(
+                    models.Q(skills_known__isnull=True) &
+                    models.Q(skills_available__isnull=True) &
+                    models.Q(skills_wanted__isnull=True)
+                ).distinct()
+
+        return queryset
 
 @extend_schema_view(
     list=extend_schema(

--- a/users/views.py
+++ b/users/views.py
@@ -69,6 +69,7 @@ class UsersViewSet(viewsets.ReadOnlyModelViewSet):
         has_skills_known = self.request.query_params.get('has_skills_known')
         has_skills_available = self.request.query_params.get('has_skills_available')
         has_skills_wanted = self.request.query_params.get('has_skills_wanted')
+        has_any_skills = self.request.query_params.get('has_any_skills')
 
         if has_skills_known is not None:
             if has_skills_known.lower() == 'true':


### PR DESCRIPTION
This pull request includes several enhancements to the `users/views.py` file, focusing on adding new filtering capabilities and improving the search functionality for user profiles. The most important changes include adding new query parameters for filtering users based on their skills, updating the filter backends, and implementing a custom `get_queryset` method to handle the new filters.

Enhancements to filtering and search functionality:

* Added new query parameters (`has_skills_known`, `has_skills_available`, `has_skills_wanted`, `has_any_skills`) to filter users based on their skills.
* Implemented a custom `get_queryset` method in the `UsersViewSet` class to apply the new skill filters to the queryset.