### PR TITLE
Add filtering capabilities for organizations

### DIFF
--- a/orgs/tests/test_views.py
+++ b/orgs/tests/test_views.py
@@ -4,6 +4,8 @@ from rest_framework import status
 from orgs.models import OrganizationType, Organization, TagDiff, Document
 from users.models import CustomUser
 from users.submodels import Territory
+from skills.models import Skill
+from django.db import models
 
 
 class OrganizationViewSetTestCase(APITestCase):
@@ -252,3 +254,83 @@ class OrganizationViewSetTestCase(APITestCase):
         Document.objects.create(url='https://commons.wikimedia.org/wiki/File:filename.ext')
         response = self.client.patch('/document/1/', {'url': 'https://commons.wikimedia.org/wiki/File:filename2.ext'})
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+class OrganizationFilterViewSetTestCase(APITestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(username='test', password=str(secrets.randbits(16)))
+        self.staff_user = CustomUser.objects.create_user(username='staff', password=str(secrets.randbits(16)), is_staff=True)
+        self.client = APIClient()
+        self.organization = Organization.objects.create(display_name='Test Organization', acronym='TO')
+        self.organization.managers.add(self.user)
+
+    def test_get_queryset_as_staff(self):
+        self.client.force_authenticate(self.staff_user)
+        response = self.client.get('/organizations/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), Organization.objects.count())
+
+    def test_get_queryset_as_non_staff(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get('/organizations/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), Organization.objects.filter(managers__isnull=False).distinct().count())
+
+    def test_get_queryset_has_capacities_known_true(self):
+        self.client.force_authenticate(self.staff_user)
+        self.organization.known_capacities.add(Skill.objects.create(skill_wikidata_item="Q123456789"))
+        response = self.client.get('/organizations/', {'has_capacities_known': 'true'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), Organization.objects.filter(known_capacities__isnull=False).distinct().count())
+
+    def test_get_queryset_has_capacities_known_false(self):
+        self.client.force_authenticate(self.staff_user)
+        response = self.client.get('/organizations/', {'has_capacities_known': 'false'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), Organization.objects.filter(known_capacities__isnull=True).distinct().count())
+
+    def test_get_queryset_has_capacities_available_true(self):
+        self.client.force_authenticate(self.staff_user)
+        self.organization.available_capacities.add(Skill.objects.create(skill_wikidata_item="Q123456789"))
+        response = self.client.get('/organizations/', {'has_capacities_available': 'true'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), Organization.objects.filter(available_capacities__isnull=False).distinct().count())
+
+    def test_get_queryset_has_capacities_available_false(self):
+        self.client.force_authenticate(self.staff_user)
+        response = self.client.get('/organizations/', {'has_capacities_available': 'false'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), Organization.objects.filter(available_capacities__isnull=True).distinct().count())
+
+    def test_get_queryset_has_capacities_wanted_true(self):
+        self.client.force_authenticate(self.staff_user)
+        self.organization.wanted_capacities.add(Skill.objects.create(skill_wikidata_item="Q123456789"))
+        response = self.client.get('/organizations/', {'has_capacities_wanted': 'true'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), Organization.objects.filter(wanted_capacities__isnull=False).distinct().count())
+
+    def test_get_queryset_has_capacities_wanted_false(self):
+        self.client.force_authenticate(self.staff_user)
+        response = self.client.get('/organizations/', {'has_capacities_wanted': 'false'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), Organization.objects.filter(wanted_capacities__isnull=True).distinct().count())
+
+    def test_get_queryset_has_any_capacities_true(self):
+        self.client.force_authenticate(self.staff_user)
+        self.organization.known_capacities.add(Skill.objects.create(skill_wikidata_item="Q123456789"))
+        response = self.client.get('/organizations/', {'has_any_capacities': 'true'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), Organization.objects.filter(
+            models.Q(known_capacities__isnull=False) |
+            models.Q(available_capacities__isnull=False) |
+            models.Q(wanted_capacities__isnull=False)
+        ).distinct().count())
+
+    def test_get_queryset_has_any_capacities_false(self):
+        self.client.force_authenticate(self.staff_user)
+        response = self.client.get('/organizations/', {'has_any_capacities': 'false'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), Organization.objects.filter(
+            models.Q(known_capacities__isnull=True) &
+            models.Q(available_capacities__isnull=True) &
+            models.Q(wanted_capacities__isnull=True)
+        ).distinct().count())

--- a/orgs/views.py
+++ b/orgs/views.py
@@ -4,12 +4,39 @@ from .models import Organization, OrganizationType, TagDiff, Document
 from .serializers import OrganizationSerializer, OrganizationTypeSerializer, TagDiffSerializer, DocumentSerializer
 from users.models import CustomUser as User, Territory
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
+from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter, OpenApiTypes
+from django.db import models
 
 @extend_schema_view(
     list=extend_schema(
         summary='List all organizations.',
         description='This endpoint lists all organizations that has been activated (i.e. has at least one manager). If the user is a staff member, all organizations are listed.',
+        parameters=[
+            OpenApiParameter(
+                name='has_capacities_known',
+                description='Filter organizations that have known capacities.',
+                required=False,
+                type=OpenApiTypes.BOOL,
+            ),
+            OpenApiParameter(
+                name='has_capacities_available',
+                description='Filter organizations that have available capacities.',
+                required=False,
+                type=OpenApiTypes.BOOL,
+            ),
+            OpenApiParameter(
+                name='has_capacities_wanted',
+                description='Filter organizations that have wanted capacities.',
+                required=False,
+                type=OpenApiTypes.BOOL,
+            ),
+            OpenApiParameter(
+                name='has_any_capacities',
+                description='Filter organizations that have any capacities.',
+                required=False,
+                type=OpenApiTypes.BOOL,
+            ),
+        ]
     ),
     create=extend_schema(
         summary='Create a new organization.',
@@ -37,13 +64,52 @@ class OrganizationViewSet(viewsets.ModelViewSet):
 
 
     def get_queryset(self):
+        has_capacities_known = self.request.query_params.get('has_capacities_known', None)
+        has_capacities_wanted = self.request.query_params.get('has_capacities_wanted', None)
+        has_capacities_available = self.request.query_params.get('has_capacities_available', None)
+        has_any_capacities = self.request.query_params.get('has_any_capacities', None)
+
         user = self.request.user
         if user.is_staff:
-            return Organization.objects.all()
+            queryset = Organization.objects.all()
         else:
             # Filter organizations that have at least one manager and ensure distinct results
-            active_organizations = Organization.objects.filter(managers__isnull=False).distinct()
-            return active_organizations
+            queryset = Organization.objects.filter(managers__isnull=False).distinct()
+        
+        if has_capacities_known is not None:
+            if has_capacities_known.lower() == 'true':
+                queryset = queryset.filter(known_capacities__isnull=False).distinct()
+            elif has_capacities_known.lower() == 'false':
+                queryset = queryset.filter(known_capacities__isnull=True).distinct()
+
+        if has_capacities_wanted is not None:
+            if has_capacities_wanted.lower() == 'true':
+                queryset = queryset.filter(wanted_capacities__isnull=False).distinct()
+            elif has_capacities_wanted.lower() == 'false':
+                queryset = queryset.filter(wanted_capacities__isnull=True).distinct()
+
+        if has_capacities_available is not None:
+            if has_capacities_available.lower() == 'true':
+                queryset = queryset.filter(available_capacities__isnull=False).distinct()
+            elif has_capacities_available.lower() == 'false':
+                queryset = queryset.filter(available_capacities__isnull=True).distinct()
+
+        if has_any_capacities is not None:
+            if has_any_capacities.lower() == 'true':
+                queryset = queryset.filter(
+                    models.Q(known_capacities__isnull=False) |
+                    models.Q(available_capacities__isnull=False) |
+                    models.Q(wanted_capacities__isnull=False)
+                ).distinct()
+            elif has_any_capacities.lower() == 'false':
+                queryset = queryset.filter(
+                    models.Q(known_capacities__isnull=True) &
+                    models.Q(available_capacities__isnull=True) &
+                    models.Q(wanted_capacities__isnull=True)
+                ).distinct()
+
+        return queryset
+
 
     @extend_schema(
         summary='Create a new organization.',


### PR DESCRIPTION
This pull request introduces new filtering capabilities for organizations based on their capacities and adds corresponding tests to ensure the functionality works as expected. The changes include modifications to the `OrganizationViewSet` class and the addition of a new test case class in the test suite.

### Filtering capabilities:

* [`orgs/views.py`](diffhunk://#diff-6df9e3f87ceab9a2502dbea3a346fd86784ab096337f0530980ff8cdcd4229bbR67-R112): Added new query parameters (`has_capacities_known`, `has_capacities_available`, `has_capacities_wanted`, `has_any_capacities`) to filter organizations based on their capacities. Updated the `get_queryset` method to handle these parameters and filter the queryset accordingly.
* [`orgs/views.py`](diffhunk://#diff-6df9e3f87ceab9a2502dbea3a346fd86784ab096337f0530980ff8cdcd4229bbL7-R39): Updated the `extend_schema_view` decorator to include the new query parameters in the API documentation.

### Testing:

* [`orgs/tests/test_views.py`](diffhunk://#diff-36ad6704f210bbf2f2b7819dc247e45ef95fbb09813fa0b6c3ba99a7ae2a71a8R257-R336): Added a new test case class `OrganizationFilterViewSetTestCase` to test the new filtering capabilities. This includes tests for each of the new query parameters to ensure they filter the organizations correctly.

### Additional imports:

* [`orgs/tests/test_views.py`](diffhunk://#diff-36ad6704f210bbf2f2b7819dc247e45ef95fbb09813fa0b6c3ba99a7ae2a71a8R7-R8): Added imports for the `Skill` model and `models` module to support the new tests.
* [`orgs/views.py`](diffhunk://#diff-6df9e3f87ceab9a2502dbea3a346fd86784ab096337f0530980ff8cdcd4229bbL7-R39): Added import for the `models` module to support the new filtering logic.