### PR TITLE
Add ordering filter to bug report

### DIFF
--- a/bugs/views.py
+++ b/bugs/views.py
@@ -1,6 +1,6 @@
 from .models import Bug, Attachment
 from .serializers import BugSerializer, AttachmentSerializer
-from rest_framework import viewsets, status
+from rest_framework import viewsets, status, filters
 from rest_framework.response import Response
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter, OpenApiTypes, OpenApiResponse
 
@@ -23,6 +23,9 @@ from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiPara
 )
 class BugViewSet(viewsets.ModelViewSet):
     serializer_class = BugSerializer
+    filter_backends = [filter.OrderingFilter]
+    ordering_fields = ['created_at']
+    ordering = ['-created_at']
 
     def get_queryset(self):
         user = self.request.user

--- a/bugs/views.py
+++ b/bugs/views.py
@@ -23,7 +23,7 @@ from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiPara
 )
 class BugViewSet(viewsets.ModelViewSet):
     serializer_class = BugSerializer
-    filter_backends = [filter.OrderingFilter]
+    filter_backends = [filters.OrderingFilter]
     ordering_fields = ['created_at']
     ordering = ['-created_at']
 


### PR DESCRIPTION
This pull request includes changes to the `bugs/views.py` file to add ordering functionality to the `BugViewSet` class. The most important changes include importing the necessary `filters` module from `rest_framework` and updating the `BugViewSet` class to support ordering by the `created_at` field.

Changes to `bugs/views.py`:

* Imported the `filters` module from `rest_framework`.
* Added `filter_backends`, `ordering_fields`, and `ordering` attributes to the `BugViewSet` class to enable ordering by the `created_at` field.