### PR TITLE
Add create method to SavedItemViewSet for handling existing items

### DIFF
--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -616,6 +616,18 @@ class SavedItemViewSetTestCase(TestCase):
         response = self.client.post('/saved_item/', data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_create_saved_item_already_exists(self):
+        SavedItem.objects.create(user=self.user, relation='sharer', entity='user', related_user=CustomUser.objects.get(username='test2'))
+        data = {'relation': 'sharer', 'entity': 'user', 'entity_id': CustomUser.objects.get(username='test2').pk}
+        response = self.client.post('/saved_item/', data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_208_ALREADY_REPORTED)
+
+    def test_create_saved_item_invalid_entity(self):
+        data = {'relation': 'sharer', 'entity': 'invalid', 'entity_id': 1}
+        response = self.client.post('/saved_item/', data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['message'], 'Invalid entity type.')
+
     def test_delete_saved_item(self):
         saved_item = SavedItem.objects.create(user=self.user, relation='sharer', entity='user', related_user=CustomUser.objects.get(username='test2'))
 

--- a/users/views.py
+++ b/users/views.py
@@ -448,6 +448,23 @@ class SavedItemViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
 
+    def create(self, request, *args, **kwargs):
+        user = request.user
+        relation = request.data.get('relation')
+        entity = request.data.get('entity')
+        entity_id = request.data.get('entity_id')
+
+        if entity not in ['org', 'user']:
+            return Response({'message': 'Invalid entity type.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        existing_item = SavedItem.objects.filter(user=user, relation=relation, entity=entity, related_user_id=entity_id).first()
+
+        if existing_item:
+            serializer = self.get_serializer(existing_item)
+            return Response(serializer.data, status=status.HTTP_202_ACCEPTED)
+
+        return super().create(request, *args, **kwargs)
+
     @extend_schema(exclude=True)
     def partial_update(self, request, *args, **kwargs):
         response = {'message': 'Partial updates are not allowed for saved items.'}

--- a/users/views.py
+++ b/users/views.py
@@ -467,7 +467,7 @@ class SavedItemViewSet(viewsets.ModelViewSet):
 
         if existing_item:
             serializer = self.get_serializer(existing_item)
-            return Response(serializer.data, status=status.HTTP_202_ACCEPTED)
+            return Response(serializer.data, status=status.HTTP_208_ALREADY_REPORTED)
 
         return super().create(request, *args, **kwargs)
 

--- a/users/views.py
+++ b/users/views.py
@@ -454,10 +454,16 @@ class SavedItemViewSet(viewsets.ModelViewSet):
         entity = request.data.get('entity')
         entity_id = request.data.get('entity_id')
 
-        if entity not in ['org', 'user']:
+        if entity == 'org':
+            existing_item = SavedItem.objects.filter(
+                user=user, relation=relation, entity='org', related_org_id=entity_id
+            ).first()
+        elif entity == 'user':
+            existing_item = SavedItem.objects.filter(
+                user=user, relation=relation, entity='user', related_user_id=entity_id
+            ).first()
+        else:
             return Response({'message': 'Invalid entity type.'}, status=status.HTTP_400_BAD_REQUEST)
-
-        existing_item = SavedItem.objects.filter(user=user, relation=relation, entity=entity, related_user_id=entity_id).first()
 
         if existing_item:
             serializer = self.get_serializer(existing_item)


### PR DESCRIPTION
This pull request introduces a new `create` method in the `users/views.py` file to handle the creation of saved items with additional validation and existing item checks.

Changes in `users/views.py`:

* Added a `create` method to handle saved items creation, including validation for `entity` type and checks for existing items before creating new ones.