### PR TITLE
Open routes as ReadOnly when not authenticated

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -147,7 +147,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # Rest
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated',
+        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'knox.auth.TokenAuthentication',

--- a/bugs/views.py
+++ b/bugs/views.py
@@ -2,6 +2,7 @@ from .models import Bug, Attachment
 from .serializers import BugSerializer, AttachmentSerializer
 from rest_framework import viewsets, status, filters
 from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter, OpenApiTypes, OpenApiResponse
 
 @extend_schema_view(
@@ -23,6 +24,7 @@ from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiPara
 )
 class BugViewSet(viewsets.ModelViewSet):
     serializer_class = BugSerializer
+    permission_classes = [IsAuthenticated]
     filter_backends = [filters.OrderingFilter]
     ordering_fields = ['created_at']
     ordering = ['-created_at']
@@ -108,6 +110,7 @@ class BugViewSet(viewsets.ModelViewSet):
 )
 class AttachmentViewSet(viewsets.ModelViewSet):
     serializer_class = AttachmentSerializer
+    permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
         user = self.request.user

--- a/message/views.py
+++ b/message/views.py
@@ -2,6 +2,7 @@ from .models import Message
 from .serializers import MessageSerializer
 from rest_framework import status, viewsets, filters
 from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter, OpenApiTypes
 
 @extend_schema_view(
@@ -21,6 +22,7 @@ from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiPara
 )
 class MessageViewSet(viewsets.ModelViewSet):
     serializer_class = MessageSerializer
+    permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
         user = self.request.user

--- a/orgs/tests/test_views.py
+++ b/orgs/tests/test_views.py
@@ -18,7 +18,7 @@ class OrganizationViewSetTestCase(APITestCase):
     
     def test_get_orgs_list_unauthenticated(self):
         response = self.client.get('/organizations/')
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_create_org_unauthenticated(self):
         org_data = {

--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -134,7 +134,7 @@ class QuickListViewSetTestCase(TestCase):
 
     def test_list_unauthenticated(self):
         response = self.client.get('/list/')
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_list_authenticated_unespecific(self):
         self.client.force_authenticate(self.user)

--- a/users/views.py
+++ b/users/views.py
@@ -6,6 +6,7 @@ from events.models import Events
 from projects.models import Project
 from rest_framework import status, viewsets, filters
 from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
 from django.db import models
 from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
@@ -133,6 +134,7 @@ class UsersViewSet(viewsets.ReadOnlyModelViewSet):
 class ProfileViewSet(viewsets.ModelViewSet):
     serializer_class = ProfileSerializer
     queryset = Profile.objects.all()
+    permission_classes = [IsAuthenticated]
     http_method_names = ['get', 'put', 'head', 'delete', 'options']
 
     def get_queryset(self):
@@ -455,6 +457,7 @@ class UsersByTagViewSet(viewsets.ReadOnlyModelViewSet):
 )
 class SavedItemViewSet(viewsets.ModelViewSet):
     serializer_class = SavedItemSerializer
+    permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
         return SavedItem.objects.filter(user=self.request.user)


### PR DESCRIPTION
This pull request introduces changes to permission handling across multiple views and modifies test cases to align with the updated permissions. The main updates include switching to more permissive default permissions for the REST framework, adding explicit `IsAuthenticated` permissions to several viewsets, and adjusting test cases to reflect the new behavior.

### Permission Updates in Views:

* [`CapX/settings.py`](diffhunk://#diff-6f9b02506e9090171d696773b3cca52c9ee9c89a1cd88bb5c4a4c97b5deee942L150-R150): Changed the default permission class from `IsAuthenticated` to `IsAuthenticatedOrReadOnly`, allowing unauthenticated users to perform read-only actions.
* `bugs/views.py`, `message/views.py`, and `users/views.py`: Added `permission_classes = [IsAuthenticated]` to `BugViewSet`, `AttachmentViewSet`, `MessageViewSet`, `ProfileViewSet`, and `SavedItemViewSet` to enforce authentication for these endpoints. [[1]](diffhunk://#diff-6a06bde47871e6cdee15d294ef94d3bbcba8c31193b08970027c449626467981R27) [[2]](diffhunk://#diff-6a06bde47871e6cdee15d294ef94d3bbcba8c31193b08970027c449626467981R113) [[3]](diffhunk://#diff-dafef799b2614fced04804eca8e3c67fc3de5ec72e8eb50145e876f7184f8f85R25) [[4]](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47R137) [[5]](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47R460)

### Test Case Adjustments:

* [`orgs/tests/test_views.py`](diffhunk://#diff-36ad6704f210bbf2f2b7819dc247e45ef95fbb09813fa0b6c3ba99a7ae2a71a8L21-R21): Updated the `test_get_orgs_list_unauthenticated` test to expect an HTTP 200 OK response instead of HTTP 401 Unauthorized, reflecting the new `IsAuthenticatedOrReadOnly` permission.
* [`users/tests/test_views.py`](diffhunk://#diff-9fb748ec46eb9cc57206c1be66852bcfc9a05323986ab387e8c1dd72711efe65L137-R137): Modified the `test_list_unauthenticated` test to expect an HTTP 400 Bad Request response instead of HTTP 401 Unauthorized, likely due to changes in validation or request handling.