### PR TITLE
Add ordering functionality to MessageViewSet

### DIFF
--- a/message/views.py
+++ b/message/views.py
@@ -21,6 +21,9 @@ from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiPara
 )
 class MessageViewSet(viewsets.ModelViewSet):
     serializer_class = MessageSerializer
+    filter_backends = [filters.OrderingFilter]
+    ordering_fields = ['date']
+    ordering = ['-date']
 
     def get_queryset(self):
         user = self.request.user


### PR DESCRIPTION
This pull request introduces a change to the `MessageViewSet` class in `message/views.py` to support ordering of messages by date. 

Enhancements to message ordering:

* [`message/views.py`](diffhunk://#diff-dafef799b2614fced04804eca8e3c67fc3de5ec72e8eb50145e876f7184f8f85R24-R26): Added `filter_backends` with `OrderingFilter`, specified `ordering_fields` to allow ordering by the `date` field, and set the default ordering to descending by `date`.