### PR TITLE
Add command to deactivate locked Wikimedia usernames

### DIFF
--- a/users/management/commands/locks.py
+++ b/users/management/commands/locks.py
@@ -1,16 +1,13 @@
 from django.core.management.base import BaseCommand
+from users.models import CustomUser
 import requests
 
 class Command(BaseCommand):
-    help = 'Check if Wikimedia usernames are locked and unactivate them locally'
+    help = 'Check if Wikimedia usernames are locked and deactivate them locally'
 
     def handle(self, *args, **kwargs):
-        from users.models import CustomUser
-
-        # Get all users with a Wikimedia username
         users = CustomUser.objects.all()
         for user in users:
-            # Check if the username is locked
             params = {
                 'action': 'query',
                 'meta': 'globaluserinfo',
@@ -18,12 +15,18 @@ class Command(BaseCommand):
                 'format': 'json',
                 'formatversion': '2',
             }
-            response = requests.get('https://meta.wikimedia.org/w/api.php', params=params)
+
+            try:
+                response = requests.get('https://meta.wikimedia.org/w/api.php', params=params)
+                response.raise_for_status()  # Raise an error for bad responses
+            except Exception as e:
+                self.stdout.write(self.style.ERROR(f'Error fetching data for user {user.username}: {e}'))
+                continue
+            
             data = response.json()
             if 'globaluserinfo' in data['query']:
                 user_info = data['query']['globaluserinfo']
                 if 'locked' in user_info and user_info['locked']:
-                    # Unactivate the user locally
                     user.is_active = False
                     user.save()
                     self.stdout.write(self.style.SUCCESS(f'User {user.username} is locked and has been deactivated.'))

--- a/users/management/commands/locks.py
+++ b/users/management/commands/locks.py
@@ -1,0 +1,34 @@
+from django.core.management.base import BaseCommand
+import requests
+
+class Command(BaseCommand):
+    help = 'Check if Wikimedia usernames are locked and unactivate them locally'
+
+    def handle(self, *args, **kwargs):
+        from users.models import CustomUser
+
+        # Get all users with a Wikimedia username
+        users = CustomUser.objects.all()
+        for user in users:
+            # Check if the username is locked
+            params = {
+                'action': 'query',
+                'meta': 'globaluserinfo',
+                'guiuser': user.username,
+                'format': 'json',
+                'formatversion': '2',
+            }
+            response = requests.get('https://meta.wikimedia.org/w/api.php', params=params)
+            data = response.json()
+            if 'globaluserinfo' in data['query']:
+                user_info = data['query']['globaluserinfo']
+                if 'locked' in user_info and user_info['locked']:
+                    # Unactivate the user locally
+                    user.is_active = False
+                    user.save()
+                    self.stdout.write(self.style.SUCCESS(f'User {user.username} is locked and has been deactivated.'))
+                else:
+                    self.stdout.write(self.style.NOTICE(f'User {user.username} is not locked.'))
+            else:
+                self.stdout.write(self.style.WARNING(f'User {user.username} not found in Wikimedia.'))
+        self.stdout.write(self.style.SUCCESS('All users have been checked.'))

--- a/users/management/commands/locks.py
+++ b/users/management/commands/locks.py
@@ -24,14 +24,11 @@ class Command(BaseCommand):
                 continue
             
             data = response.json()
-            if 'globaluserinfo' in data['query']:
-                user_info = data['query']['globaluserinfo']
-                if 'locked' in user_info and user_info['locked']:
-                    user.is_active = False
-                    user.save()
-                    self.stdout.write(self.style.SUCCESS(f'User {user.username} is locked and has been deactivated.'))
-                else:
-                    self.stdout.write(self.style.NOTICE(f'User {user.username} is not locked.'))
+            user_info = data['query']['globaluserinfo']
+            if 'locked' in user_info and user_info['locked']:
+                user.is_active = False
+                user.save()
+                self.stdout.write(self.style.SUCCESS(f'User {user.username} is locked and has been deactivated.'))
             else:
-                self.stdout.write(self.style.WARNING(f'User {user.username} not found in Wikimedia.'))
+                self.stdout.write(self.style.NOTICE(f'User {user.username} is not locked.'))
         self.stdout.write(self.style.SUCCESS('All users have been checked.'))

--- a/users/management/commands/locks.py
+++ b/users/management/commands/locks.py
@@ -5,7 +5,8 @@ import requests
 class Command(BaseCommand):
     help = 'Check if Wikimedia usernames are locked and deactivate them locally'
 
-    def handle(self, *args, **kwargs):
+    def handle(self, *args, **options):
+        self.verbosity = options.get('verbosity', 1)
         users = CustomUser.objects.all()
         for user in users:
             params = {
@@ -28,7 +29,8 @@ class Command(BaseCommand):
             if 'locked' in user_info and user_info['locked']:
                 user.is_active = False
                 user.save()
-                self.stdout.write(self.style.SUCCESS(f'User {user.username} is locked and has been deactivated.'))
+                if self.verbosity >= 2:
+                    self.stdout.write(self.style.SUCCESS(f'User {user.username} is locked and has been deactivated.'))
             else:
-                self.stdout.write(self.style.NOTICE(f'User {user.username} is not locked.'))
-        self.stdout.write(self.style.SUCCESS('All users have been checked.'))
+                if self.verbosity >= 2:
+                    self.stdout.write(self.style.NOTICE(f'User {user.username} is not locked.'))

--- a/users/models.py
+++ b/users/models.py
@@ -8,6 +8,15 @@ from skills.models import Skill
 from users.submodels import Territory, Language, WikimediaProject, Avatar, DataHash
 from django.core.validators import RegexValidator
 from django.core.exceptions import ValidationError
+from django.db.models import Manager
+
+
+class ActiveUserManager(UserManager):
+    """
+    Custom manager to filter out inactive users by default.
+    """
+    def get_queryset(self):
+        return super().get_queryset().filter(is_active=True)
 
 
 class CustomUser(AbstractBaseUser, PermissionsMixin):
@@ -39,10 +48,18 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
         blank=False
     )
 
-    objects = UserManager()
+    objects = ActiveUserManager()  # Use the custom manager
+    all_objects = UserManager()  # Add this to access all users if needed
     USERNAME_FIELD = 'username'
     EMAIL_FIELD = 'email'
 
+
+class ActiveProfileManager(Manager):
+    """
+    Custom manager to filter out profiles linked to inactive users.
+    """
+    def get_queryset(self):
+        return super().get_queryset().filter(user__is_active=True)
 
 class Profile(models.Model):
     PRONOUNS = (
@@ -188,6 +205,9 @@ class Profile(models.Model):
         auto_now=True,
         help_text="Timestamp of the last update to the profile."
     )
+
+    objects = ActiveProfileManager()  # Use the custom manager
+    all_objects = Manager()  # Add this to access all profiles if needed
 
     def save(self, *args, **kwargs):
         """

--- a/users/tests/test_locks.py
+++ b/users/tests/test_locks.py
@@ -23,10 +23,11 @@ class LocksCommandTestCase(TestCase):
         mock_response.raise_for_status = MagicMock()
         mock_get.return_value = mock_response
 
-        call_command('locks')
+        call_command('locks', verbosity=2)
 
         self.user_locked.refresh_from_db()
         self.assertFalse(self.user_locked.is_active)
+        mock_stdout.assert_called_with('User lockeduser is locked.\n')
 
     @patch('sys.stdout.write')
     @patch('users.management.commands.locks.requests.get')
@@ -42,10 +43,11 @@ class LocksCommandTestCase(TestCase):
         mock_response.raise_for_status = MagicMock()
         mock_get.return_value = mock_response
 
-        call_command('locks')
+        call_command('locks', verbosity=2)
 
         self.user_active.refresh_from_db()
         self.assertTrue(self.user_active.is_active)
+        mock_stdout.assert_called_with('User activeuser is not locked.\n')
 
     @patch('sys.stdout.write')
     @patch('users.management.commands.locks.requests.get')

--- a/users/tests/test_locks.py
+++ b/users/tests/test_locks.py
@@ -1,0 +1,58 @@
+from django.core.management import call_command
+from django.test import TestCase
+from unittest.mock import patch, MagicMock
+from users.models import CustomUser
+
+class LocksCommandTestCase(TestCase):
+    def setUp(self):
+        self.user_active = CustomUser.objects.create_user(username='activeuser', password='password', is_active=True)
+        self.user_locked = CustomUser.objects.create_user(username='lockeduser', password='password', is_active=True)
+
+    @patch('users.management.commands.locks.requests.get')
+    def test_handle_locked_user(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'query': {
+                'globaluserinfo': {
+                    'id': 12345678,
+                    'locked': True
+                }
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        call_command('locks')
+
+        self.user_locked.refresh_from_db()
+        self.assertFalse(self.user_locked.is_active)
+
+    @patch('users.management.commands.locks.requests.get')
+    def test_handle_active_user(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'query': {
+                'globaluserinfo': {
+                    'id': 12345678
+                }
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        call_command('locks')
+
+        self.user_active.refresh_from_db()
+        self.assertTrue(self.user_active.is_active)
+
+    @patch('users.management.commands.locks.requests.get')
+    def test_handle_request_error(self, mock_get):
+        mock_get.side_effect = Exception("Request failed")
+
+        call_command('locks')
+
+        self.user_active.refresh_from_db()
+        self.user_locked.refresh_from_db()
+
+        self.assertTrue(self.user_active.is_active)
+        self.assertTrue(self.user_locked.is_active)

--- a/users/tests/test_locks.py
+++ b/users/tests/test_locks.py
@@ -5,8 +5,7 @@ from users.models import CustomUser
 
 class LocksCommandTestCase(TestCase):
     def setUp(self):
-        self.user_active = CustomUser.objects.create_user(username='activeuser', password='password', is_active=True)
-        self.user_locked = CustomUser.objects.create_user(username='lockeduser', password='password', is_active=True)
+        self.user = CustomUser.objects.create_user(username='activeuser', password='password', is_active=True)
 
     @patch('sys.stdout.write')
     @patch('users.management.commands.locks.requests.get')
@@ -25,9 +24,9 @@ class LocksCommandTestCase(TestCase):
 
         call_command('locks', verbosity=2)
 
-        self.user_locked.refresh_from_db()
-        self.assertFalse(self.user_locked.is_active)
-        mock_stdout.assert_called_with('User lockeduser is locked.\n')
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
+        mock_stdout.assert_called_with('User activeuser is locked and has been deactivated.\n')
 
     @patch('sys.stdout.write')
     @patch('users.management.commands.locks.requests.get')
@@ -45,8 +44,8 @@ class LocksCommandTestCase(TestCase):
 
         call_command('locks', verbosity=2)
 
-        self.user_active.refresh_from_db()
-        self.assertTrue(self.user_active.is_active)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_active)
         mock_stdout.assert_called_with('User activeuser is not locked.\n')
 
     @patch('sys.stdout.write')
@@ -56,8 +55,5 @@ class LocksCommandTestCase(TestCase):
 
         call_command('locks', verbosity=2)
 
-        self.user_active.refresh_from_db()
-        self.user_locked.refresh_from_db()
-
-        self.assertTrue(self.user_active.is_active)
-        self.assertTrue(self.user_locked.is_active)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_active)

--- a/users/tests/test_locks.py
+++ b/users/tests/test_locks.py
@@ -8,8 +8,9 @@ class LocksCommandTestCase(TestCase):
         self.user_active = CustomUser.objects.create_user(username='activeuser', password='password', is_active=True)
         self.user_locked = CustomUser.objects.create_user(username='lockeduser', password='password', is_active=True)
 
+    @patch('sys.stdout.write')
     @patch('users.management.commands.locks.requests.get')
-    def test_handle_locked_user(self, mock_get):
+    def test_handle_locked_user(self, mock_get, mock_stdout):
         mock_response = MagicMock()
         mock_response.json.return_value = {
             'query': {
@@ -27,8 +28,9 @@ class LocksCommandTestCase(TestCase):
         self.user_locked.refresh_from_db()
         self.assertFalse(self.user_locked.is_active)
 
+    @patch('sys.stdout.write')
     @patch('users.management.commands.locks.requests.get')
-    def test_handle_active_user(self, mock_get):
+    def test_handle_active_user(self, mock_get, mock_stdout):
         mock_response = MagicMock()
         mock_response.json.return_value = {
             'query': {
@@ -45,11 +47,12 @@ class LocksCommandTestCase(TestCase):
         self.user_active.refresh_from_db()
         self.assertTrue(self.user_active.is_active)
 
+    @patch('sys.stdout.write')
     @patch('users.management.commands.locks.requests.get')
-    def test_handle_request_error(self, mock_get):
+    def test_handle_request_error(self, mock_get, mock_stdout):
         mock_get.side_effect = Exception("Request failed")
 
-        call_command('locks')
+        call_command('locks', verbosity=2)
 
         self.user_active.refresh_from_db()
         self.user_locked.refresh_from_db()


### PR DESCRIPTION
This pull request introduces a new management command to check and deactivate Wikimedia-locked users, along with updates to the `CustomUser` and `Profile` models to include custom managers for filtering active users and profiles. The most important changes are grouped below:

### New Management Command for User Lock Checks:
* Added a new Django management command in `users/management/commands/locks.py` to check if Wikimedia usernames are locked via the Wikimedia API and deactivate them locally if necessary. The command provides detailed feedback for each user.

### Enhancements to User and Profile Models:
* Introduced `ActiveUserManager` in `users/models.py` to filter only active users by default and updated the `CustomUser` model to use this manager as its default, while retaining access to all users through `all_objects`. [[1]](diffhunk://#diff-9d9b19f5976005b432bc617914003383689329533cd1dd7045352a02ad07ac7bR11-R19) [[2]](diffhunk://#diff-9d9b19f5976005b432bc617914003383689329533cd1dd7045352a02ad07ac7bL42-R63)
* Introduced `ActiveProfileManager` in `users/models.py` to filter profiles linked to active users by default and updated the `Profile` model to use this manager, while retaining access to all profiles through `all_objects`. [[1]](diffhunk://#diff-9d9b19f5976005b432bc617914003383689329533cd1dd7045352a02ad07ac7bL42-R63) [[2]](diffhunk://#diff-9d9b19f5976005b432bc617914003383689329533cd1dd7045352a02ad07ac7bR209-R211)