### PR TITLE
Enhance LetsConnectLog: make fields optional in serializer and add ordering to viewset

### DIFF
--- a/users/letsconnect.py
+++ b/users/letsconnect.py
@@ -13,12 +13,16 @@ from rest_framework import status
 from .serializers import LetsConnectLogSerializer
 from .models import LetsConnectLog
 from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiTypes
+from rest_framework import filters
 
 
 class LetsConnectViewSet(viewsets.GenericViewSet):
     permission_classes = [IsAuthenticated]
     serializer_class = LetsConnectLogSerializer
-    
+    filter_backends = [filters.OrderingFilter]
+    ordering_fields = ['timestamp']
+    ordering = ['-timestamp']
+
     def get_queryset(self):
         return LetsConnectLog.objects.filter(user=self.request.user)
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -223,12 +223,12 @@ class SavedItemSerializer(serializers.ModelSerializer):
 
 
 class LetsConnectLogSerializer(serializers.ModelSerializer):
-    full_name = serializers.CharField(write_only=True)
-    email = serializers.CharField(write_only=True)
-    role = serializers.CharField(write_only=True)
-    area = serializers.CharField(write_only=True)
-    gender = serializers.CharField(write_only=True)
-    age = serializers.CharField(write_only=True)
+    full_name = serializers.CharField(write_only=True, required=False)
+    email = serializers.CharField(write_only=True, required=False)
+    role = serializers.CharField(write_only=True, required=False)
+    area = serializers.CharField(write_only=True, required=False)
+    gender = serializers.CharField(write_only=True, required=False)
+    age = serializers.CharField(write_only=True, required=False)
 
     class Meta:
         model = LetsConnectLog


### PR DESCRIPTION
Make fields optional in the LetsConnectLog serializer and implement ordering in the viewset for better data retrieval.