### PR TITLE
Limits on profile

### DIFF
--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -127,6 +127,37 @@ class ProfileViewSetTestCase(TestCase):
         lang_prof = LanguageProficiency.objects.get(profile=self.user.profile, language=language)
         self.assertEqual(lang_prof.proficiency, '3')
 
+    def test_update_too_many_language_proficiency(self):
+        # Create 21 languages
+        languages = [Language.objects.create(language_name=f"Language {i}", language_code=f"lang{i}") for i in range(21)]
+        url = '/profile/' + str(self.user.pk) + '/'
+        data = self.client.get(url).data
+        self.assertEqual(data['language'], [])
+        data['language'] = [{'id': lang.id, 'proficiency': '3'} for lang in languages]
+        response = self.client.put(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    def test_update_too_many_territory(self):
+        # Create 11 territories
+        territories = [Territory.objects.create(territory_name=f"Territory {i}") for i in range(11)]
+        url = '/profile/' + str(self.user.pk) + '/'
+        data = self.client.get(url).data
+        self.assertEqual(data['territory'], [])
+        data['territory'] = [territory.id for territory in territories]
+        response = self.client.put(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    def test_update_too_many_affiliation(self):
+        # Create 11 organizations
+        organizations = [Organization.objects.create(display_name=f"Organization {i}", acronym=f"Org{i}") for i in range(11)]
+        url = '/profile/' + str(self.user.pk) + '/'
+        data = self.client.get(url).data
+        self.assertEqual(data['affiliation'], [])
+        data['affiliation'] = [organization.id for organization in organizations]
+        response = self.client.put(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+
 class QuickListViewSetTestCase(TestCase):
     def setUp(self):
         self.user = CustomUser.objects.create_user(username='test', password=str(secrets.randbits(16)))

--- a/users/views.py
+++ b/users/views.py
@@ -212,8 +212,28 @@ class ProfileViewSet(viewsets.ModelViewSet):
             if skills_available - skills_known:
                 response = {'message': 'You cannot add a skill to skills_available that is not in skills_known.'}
                 return Response(response, status=status.HTTP_409_CONFLICT)
-            else:
-                return super().update(request, *args, **kwargs)
+            
+            # Establish limits for the number of territories, languages, and affiliations
+            max_languages = 20
+            max_territories = 10
+            max_affiliations = 10
+
+            territories = len(request.data.get('territory', []) or [])
+            languages = len(request.data.get('language', {}) or {})
+            affiliations = len(request.data.get('affiliation', []) or [])
+
+            if territories > max_territories:
+                response = {'message': f'You cannot add more than {max_territories} territories.'}
+                return Response(response, status=status.HTTP_409_CONFLICT)
+            if languages > max_languages:
+                response = {'message': f'You cannot add more than {max_languages} languages.'}
+                return Response(response, status=status.HTTP_409_CONFLICT)
+            if affiliations > max_affiliations:
+                response = {'message': f'You cannot add more than {max_affiliations} affiliations.'}
+                return Response(response, status=status.HTTP_409_CONFLICT)
+
+            # If all checks pass, proceed with the update
+            return super().update(request, *args, **kwargs)
 
     
     @extend_schema(


### PR DESCRIPTION
This pull request introduces validation logic to enforce limits on the number of territories, languages, and affiliations a user can add to their profile, along with corresponding test cases to ensure these limits are respected.

### Validation logic for profile updates:
* [`users/views.py`](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47L215-R235): Added checks in the `update` method to enforce maximum limits of 20 languages, 10 territories, and 10 affiliations. If these limits are exceeded, an HTTP 409 Conflict response is returned with an appropriate error message.

### Test cases for validation:
* `users/tests/test_views.py`: Added three new test cases:
  - [`test_update_too_many_language_proficiency`](diffhunk://#diff-9fb748ec46eb9cc57206c1be66852bcfc9a05323986ab387e8c1dd72711efe65R130-R160): Verifies that attempting to add more than 20 languages results in an HTTP 409 Conflict response.
  - [`test_update_too_many_territory`](diffhunk://#diff-9fb748ec46eb9cc57206c1be66852bcfc9a05323986ab387e8c1dd72711efe65R130-R160): Verifies that attempting to add more than 10 territories results in an HTTP 409 Conflict response.
  - [`test_update_too_many_affiliation`](diffhunk://#diff-9fb748ec46eb9cc57206c1be66852bcfc9a05323986ab387e8c1dd72711efe65R130-R160): Verifies that attempting to add more than 10 affiliations results in an HTTP 409 Conflict response.