### PR TITLE
Exclude inactive related users from SavedItem queryset

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -483,7 +483,7 @@ class SavedItemViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        return SavedItem.objects.filter(user=self.request.user)
+        return SavedItem.objects.filter(user=self.request.user).exclude(related_user__is_active=False)
 
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)


### PR DESCRIPTION
This pull request makes a small but important change to the `SavedItemViewSet` class in `users/views.py`. The change ensures that inactive users are excluded from the queryset when fetching saved items.

* [`users/views.py`](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47L486-R486): Updated the `get_queryset` method in `SavedItemViewSet` to exclude saved items related to inactive users by adding a filter condition `.exclude(related_user__is_active=False)`.