### PR TITLE
Add badge listing functionality to QuickListViewSet

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -166,6 +166,6 @@ REST_KNOX = {'TOKEN_TTL': timedelta(days=30)}
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Capacity Exchange (CapX) API',
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
-    'VERSION': '2.1.23',
+    'VERSION': '2.1.24',
     'SERVE_INCLUDE_SCHEMA': True,
 }

--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -285,6 +285,16 @@ class QuickListViewSetTestCase(TestCase):
         expected_data = {project.pk: project.display_name for project in projects}
         self.assertEqual(response.data, expected_data)
 
+    def test_list_badges(self):
+        Badge.objects.create(name='Sample Badge')
+        Badge.objects.create(name='Sample Badge 2')
+        self.client.force_authenticate(self.user)
+
+        response = self.client.get('/list/badges/')
+        badges = Badge.objects.all()
+        expected_data = {badge.pk: badge.name for badge in badges}
+        self.assertEqual(response.data, expected_data)
+
 
 class UsersBySkillTestCase(TestCase):
     def setUp(self):

--- a/users/views.py
+++ b/users/views.py
@@ -346,6 +346,8 @@ class QuickListViewSet(viewsets.ReadOnlyModelViewSet):
             return Project.objects.all()
         elif list_type == 'skills':
             return Skill.objects.all()
+        elif list_type == 'badges':
+            return Badge.objects.all()
         else:
             # Dummy empty queryset to avoid errors in the schema generation
             return Profile.objects.none()
@@ -364,7 +366,7 @@ class QuickListViewSet(viewsets.ReadOnlyModelViewSet):
                 OpenApiParameter.PATH,
                 required=True,
                 description='The type of list to retrieve.',
-                enum=['language', 'wikimedia_project', 'affiliation', 'territory', 'skills', 'event', 'project'],
+                enum=['language', 'wikimedia_project', 'affiliation', 'territory', 'skills', 'event', 'project', 'badges'],
             ),
         ],
         responses={(200, 'application/json'): {


### PR DESCRIPTION
This pull request introduces functionality to list badges in the application, including updates to the views, serializers, and test cases. The changes ensure that badges can be retrieved through the API and properly tested.

### Functionality for listing badges:

* [`users/views.py`](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47R349-R350): Updated the `get_queryset` method to include a case for `list_type == 'badges'`, allowing retrieval of all `Badge` objects.
* [`users/views.py`](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47L367-R369): Modified the `get_serializer_class` method to add `badges` to the enumeration of list types in the OpenAPI parameter description.

### Test coverage for badges listing:

* [`users/tests/test_views.py`](diffhunk://#diff-9fb748ec46eb9cc57206c1be66852bcfc9a05323986ab387e8c1dd72711efe65R288-R297): Added a new test method, `test_list_badges`, to verify the functionality of listing badges, ensuring the API returns the correct data.