### PR TITLE
Add user agent header to API requests in export and locks commands

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -166,6 +166,6 @@ REST_KNOX = {'TOKEN_TTL': timedelta(days=30)}
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Capacity Exchange (CapX) API',
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
-    'VERSION': '2.1.30',
+    'VERSION': '2.1.31',
     'SERVE_INCLUDE_SCHEMA': True,
 }

--- a/users/management/commands/export.py
+++ b/users/management/commands/export.py
@@ -24,6 +24,10 @@ class Command(BaseCommand):
             return item.replace(',', '&#44;') if isinstance(item, str) else item
         return '[' + ', '.join(str(escape_commas(item)) for item in data_list) + ']'
 
+    def get_user_agent(self):
+        version = getattr(settings, "SPECTACULAR_SETTINGS", {}).get("VERSION", "dev")
+        return f"CapacityExchangeBot/{version}"
+
     def get_meta_wiki_users(self):
         query_params = {
             'action': 'query',
@@ -38,7 +42,7 @@ class Command(BaseCommand):
         response = requests.get(
             'https://meta.wikimedia.org/w/api.php',
             params=query_params,
-            headers={'User-Agent': 'CapacityExchangeBot/1.0'}
+            headers={'User-Agent': self.get_user_agent()}
         )
         if self.verbosity >= 2:
             self.stdout.write(f"Meta wiki users response: {response.json()}")
@@ -92,7 +96,7 @@ class Command(BaseCommand):
                 badges.append(badge_data)
 
             api = f"https://learn.wiki/api/badges/v1/assertions/user/{main_username}/"
-            response = requests.get(api)
+            response = requests.get(api, headers={'User-Agent': self.get_user_agent()})
             if response.status_code == 200 and response.json().get('results', None):
                 for badge in response.json().get('results'):
                     badge_data = f"{badge['badge_class']['display_name']}§Open Badges - Logo.png§{badge['assertion_url']}"
@@ -184,7 +188,7 @@ class Command(BaseCommand):
             "type": "login",
             "format": "json"
         }
-        response = session.get(url=url, params=params)
+        response = session.get(url=url, params=params, headers={'User-Agent': self.get_user_agent()})
         data = response.json()
         if self.verbosity >= 2:
             self.stdout.write(f"Login token response: {data}")
@@ -198,7 +202,7 @@ class Command(BaseCommand):
             "lgtoken": login_token,
             "format": "json"
         }
-        response = session.post(url, data=params).json()
+        response = session.post(url, data=params, headers={'User-Agent': self.get_user_agent()}).json()
         if response['login']['result'] != 'Success':
             raise requests.exceptions.RequestException("Login failed")
         if self.verbosity >= 2:
@@ -211,7 +215,7 @@ class Command(BaseCommand):
             "meta": "tokens",
             "format": "json"
         }
-        response = session.get(url=url, params=params)
+        response = session.get(url=url, params=params, headers={'User-Agent': self.get_user_agent()})
         data = response.json()
         if self.verbosity >= 2:
             self.stdout.write(f"CSRF token response: {data}")
@@ -230,7 +234,7 @@ class Command(BaseCommand):
         if self.verbosity >= 2:
             self.stdout.write(f"Editing page {title} with text: {text}")
         
-        response = session.post(url, data=params)
+        response = session.post(url, data=params, headers={'User-Agent': self.get_user_agent()})
         return response.json()
 
     def hash_data(self, data):
@@ -273,7 +277,8 @@ class Command(BaseCommand):
         sparql_query = self.get_sparql_query(quids)
         response = requests.get(
             'https://metabase.wikibase.cloud/query/sparql',
-            params={'query': sparql_query, 'format': 'json'}
+            params={'query': sparql_query, 'format': 'json'},
+            headers={'User-Agent': self.get_user_agent()}
         )
         formatted_data = self.process_sparql_response(response, skill_dict)
         output_capacities = self.create_output_capacities(formatted_data)

--- a/users/management/commands/locks.py
+++ b/users/management/commands/locks.py
@@ -1,9 +1,14 @@
 from django.core.management.base import BaseCommand
 from users.models import CustomUser
+from django.conf import settings
 import requests
 
 class Command(BaseCommand):
     help = 'Check if Wikimedia usernames are locked and deactivate them locally'
+
+    def get_user_agent(self):
+        version = getattr(settings, "SPECTACULAR_SETTINGS", {}).get("VERSION", "dev")
+        return f"CapacityExchangeBot/{version}"
 
     def handle(self, *args, **options):
         self.verbosity = options.get('verbosity', 1)
@@ -18,7 +23,7 @@ class Command(BaseCommand):
             }
 
             try:
-                response = requests.get('https://meta.wikimedia.org/w/api.php', params=params)
+                response = requests.get('https://meta.wikimedia.org/w/api.php', params=params, headers={'User-Agent': self.get_user_agent()})
                 response.raise_for_status()  # Raise an error for bad responses
             except Exception as e:
                 self.stdout.write(self.style.ERROR(f'Error fetching data for user {user.username}: {e}'))


### PR DESCRIPTION
This pull request updates how HTTP requests are made throughout the management commands to ensure a consistent and up-to-date `User-Agent` header is used, reflecting the current application version. This is done by introducing a `get_user_agent` method in both the `export.py` and `locks.py` management commands, and refactoring all relevant requests to use this method. Additionally, the API version is incremented.

**Consistent User-Agent header usage:**

* Added a `get_user_agent` method to both `users/management/commands/export.py` and `users/management/commands/locks.py` to dynamically generate a `User-Agent` string based on the current API version from `settings.py`. [[1]](diffhunk://#diff-96345dd7b8b9904d1065330ae240a3199dea1cffc874f6e35f5ae3d0a637efa2R27-R30) [[2]](diffhunk://#diff-7f3bb30c9e9c261e63bfa01968d948afaa8ebe5f8bf8749808075cb4bb54cae8R3-R12)
* Updated all HTTP requests in `users/management/commands/export.py` (including requests to Wikimedia, LearnWiki, and Wikibase APIs) to use the new `User-Agent` header for better traceability and compliance. [[1]](diffhunk://#diff-96345dd7b8b9904d1065330ae240a3199dea1cffc874f6e35f5ae3d0a637efa2L41-R45) [[2]](diffhunk://#diff-96345dd7b8b9904d1065330ae240a3199dea1cffc874f6e35f5ae3d0a637efa2L95-R99) [[3]](diffhunk://#diff-96345dd7b8b9904d1065330ae240a3199dea1cffc874f6e35f5ae3d0a637efa2L187-R191) [[4]](diffhunk://#diff-96345dd7b8b9904d1065330ae240a3199dea1cffc874f6e35f5ae3d0a637efa2L201-R205) [[5]](diffhunk://#diff-96345dd7b8b9904d1065330ae240a3199dea1cffc874f6e35f5ae3d0a637efa2L214-R218) [[6]](diffhunk://#diff-96345dd7b8b9904d1065330ae240a3199dea1cffc874f6e35f5ae3d0a637efa2L233-R237) [[7]](diffhunk://#diff-96345dd7b8b9904d1065330ae240a3199dea1cffc874f6e35f5ae3d0a637efa2L276-R281)
* Updated the HTTP request in `users/management/commands/locks.py` to use the new `User-Agent` header.

**Version update:**

* Incremented the API version in `CapX/settings.py` from `2.1.30` to `2.1.31`.