### PR TITLE
Limit badge data formatting to 400 characters in export command

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -166,6 +166,6 @@ REST_KNOX = {'TOKEN_TTL': timedelta(days=30)}
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Capacity Exchange (CapX) API',
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
-    'VERSION': '2.1.31',
+    'VERSION': '2.1.32',
     'SERVE_INCLUDE_SCHEMA': True,
 }

--- a/users/management/commands/export.py
+++ b/users/management/commands/export.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
             user_badges = UserBadge.objects.filter(user=user, progress=100, is_displayed=True)
             for badge in user_badges:
                 image = badge.badge.picture.split('/')[-1]
-                badge_data = f"{badge.badge.name}§{image}§https://meta.wikimedia.org/wiki/Capacity_Exchange/User_Guide#Badges"
+                badge_data = f"{badge.badge.name}§{image}§"
                 badges.append(badge_data)
 
             api = f"https://learn.wiki/api/badges/v1/assertions/user/{main_username}/"
@@ -101,8 +101,14 @@ class Command(BaseCommand):
                 for badge in response.json().get('results'):
                     badge_data = f"{badge['badge_class']['display_name']}§Open Badges - Logo.png§{badge['assertion_url']}"
                     badges.append(badge_data)
-            
-            data.append(self.format_list(badges))
+
+            # Remove last badges if the formatted string exceeds 400 chars
+            formatted_badges = self.format_list(badges)
+            while len(formatted_badges) > 400 and badges:
+                badges.pop()
+                formatted_badges = self.format_list(badges)
+
+            data.append(formatted_badges)
             formatted_data.append(data)
         
         if self.verbosity >= 2:

--- a/users/tests/test_export.py
+++ b/users/tests/test_export.py
@@ -285,6 +285,18 @@ class CommandTestCase(TestCase):
         self.assertEqual(set(skills), set(expected_skills))
 
     @patch('users.management.commands.export.requests.get')
+    def test_process_profiles_with_too_many_badges(self, mock_requests_get):
+        meta_wiki_users = ['TestUser1']
+        mock_requests_get.side_effect = [
+            MagicMock(status_code=200, json=MagicMock(return_value={
+                'results': [{'badge_class': {'display_name': f'B{i}', 'course_id': f'C{i}'}, 'assertion_url': f'U{i}'} for i in range(30)]
+            }))
+        ]
+
+        formatted_data, _ = self.command.process_profiles(self.profile_serializer.data, meta_wiki_users)
+        self.assertTrue(len(formatted_data[0][3]) <= 400)
+
+    @patch('users.management.commands.export.requests.get')
     def test_process_profiles_with_missing_badges(self, mock_requests_get):
         meta_wiki_users = ['TestUser1', 'AltUser2']
 
@@ -308,6 +320,7 @@ class CommandTestCase(TestCase):
 
         self.assertEqual(formatted_data, expected_data)
         self.assertEqual(set(skills), set(expected_skills))
+
 
     @patch('users.management.commands.export.requests.Session')
     def test_handle(self, mock_session):
@@ -364,3 +377,5 @@ class AddArgumentsTestCase(TestCase):
         out = StringIO()
         call_command('export', '--dry-run', stdout=out)
         self.assertIn("Dry run mode enabled", out.getvalue())
+
+

--- a/users/tests/test_export.py
+++ b/users/tests/test_export.py
@@ -54,7 +54,7 @@ class CommandTestCase(TestCase):
             progress=100,
             is_displayed=True,
         )
-        self.def_badge = 'Badge1§File:Open_Badges_-_Logo.png§https://meta.wikimedia.org/wiki/Capacity_Exchange/User_Guide#Badges'
+        self.def_badge = 'Badge1§File:Open_Badges_-_Logo.png§'
 
         self.profile_serializer = ProfileSerializer(Profile.objects.all(), many=True)
 


### PR DESCRIPTION
This pull request introduces a safeguard to limit the length of badge data when exporting user profiles, ensuring the badge string does not exceed 400 characters. It also updates the API version and adds corresponding tests for this new behavior.

**Badge export logic improvements:**

* In `users/management/commands/export.py`, updated the badge data export logic to truncate the badge list if the formatted badge string exceeds 400 characters, preventing overly long entries.
* Removed the hardcoded badge URL from the badge data string, simplifying the badge information exported.

**Testing enhancements:**

* Added a new test (`test_process_profiles_with_too_many_badges`) in `users/tests/test_export.py` to verify that the badge string length does not exceed 400 characters when a user has many badges.
* Minor formatting and whitespace updates in the test file for clarity. [[1]](diffhunk://#diff-db6c3ff7e1e9ec7a624f61226344b51bcd56c0dc9dbbcf936a188c59c72d416fR324) [[2]](diffhunk://#diff-db6c3ff7e1e9ec7a624f61226344b51bcd56c0dc9dbbcf936a188c59c72d416fR380-R381)

**Version update:**

* Bumped the API version to `2.1.32` in `CapX/settings.py` to reflect these changes.