### PR TITLE
Order organizations by update time

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -166,6 +166,6 @@ REST_KNOX = {'TOKEN_TTL': timedelta(days=30)}
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Capacity Exchange (CapX) API',
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
-    'VERSION': '2.1.32',
+    'VERSION': '2.1.33',
     'SERVE_INCLUDE_SCHEMA': True,
 }

--- a/orgs/views.py
+++ b/orgs/views.py
@@ -4,6 +4,7 @@ from .models import Organization, OrganizationType, TagDiff, Document
 from .serializers import OrganizationSerializer, OrganizationTypeSerializer, TagDiffSerializer, DocumentSerializer
 from users.models import CustomUser as User, Territory
 from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.filters import OrderingFilter
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter, OpenApiTypes
 from django.db import models
 from events.models import Events
@@ -61,7 +62,8 @@ from events.models import Events
 class OrganizationViewSet(viewsets.ModelViewSet):
     queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ['display_name', 'update_date']
     filterset_fields = [
         'display_name',
         'acronym',


### PR DESCRIPTION
This pull request introduces a minor version bump and enhances the API's filtering capabilities for organizations. The most significant change is the addition of ordering support to the `OrganizationViewSet`, allowing API consumers to sort organizations by `display_name` or `update_date`.

API improvements:

* Added `OrderingFilter` to the `OrganizationViewSet` and specified `ordering_fields` as `display_name` and `update_date`, enabling sorting of organization listings in API responses. [[1]](diffhunk://#diff-6df9e3f87ceab9a2502dbea3a346fd86784ab096337f0530980ff8cdcd4229bbR7) [[2]](diffhunk://#diff-6df9e3f87ceab9a2502dbea3a346fd86784ab096337f0530980ff8cdcd4229bbL64-R66)

Versioning:

* Updated the API version in `SPECTACULAR_SETTINGS` from `2.1.32` to `2.1.33` to reflect the new functionality.