### PR TITLE
Refactor StatisticsView to use AuthToken for recent logins

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -166,6 +166,6 @@ REST_KNOX = {'TOKEN_TTL': timedelta(days=30)}
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Capacity Exchange (CapX) API',
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
-    'VERSION': '2.1.36',
+    'VERSION': '2.1.37',
     'SERVE_INCLUDE_SCHEMA': True,
 }

--- a/users/views.py
+++ b/users/views.py
@@ -16,6 +16,7 @@ from rest_framework.views import APIView
 from datetime import datetime
 from django.utils import timezone
 from datetime import timedelta
+from knox.models import AuthToken
 
 
 @extend_schema_view(
@@ -619,10 +620,8 @@ class StatisticsView(APIView):
             user__date_joined__gte=last_30_days,
             user__is_active=True
         ).count()
-        active_users = Profile.objects.filter(
-            user__last_login__gte=last_30_days,
-            user__is_active=True
-        ).count()
+        recent_user_ids = AuthToken.objects.filter(created__gte=last_30_days).values_list('user_id', flat=True).distinct()
+        active_users = Profile.objects.filter(user__id__in=recent_user_ids, user__is_active=True).count()
 
         # Calculate total capacities and new capacities this month
         total_capacities = Skill.objects.count()


### PR DESCRIPTION
This pull request updates how active users are calculated in the user statistics endpoint, switching from relying on the `last_login` field to using authentication token creation dates. It also includes a minor version bump for the API.

**User activity calculation improvements:**

* Changed the definition of "active users" in the statistics endpoint to count users who have created an authentication token in the last 30 days, rather than those who have logged in during that period. This provides a more accurate measure of recent activity. (`users/views.py`)
* Imported `AuthToken` from `knox.models` to support the new method for determining active users. (`users/views.py`)

**Version update:**

* Bumped API version from `2.1.36` to `2.1.37` in `SPECTACULAR_SETTINGS`. (`CapX/settings.py`)