### PR TITLE
Add drf-spectacular-sidecar to settings and requirements

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'rest_social_auth',
     'knox',
     'drf_spectacular',
+    'drf_spectacular_sidecar',
 ]
 
 MIDDLEWARE = [
@@ -168,4 +169,7 @@ SPECTACULAR_SETTINGS = {
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
     'VERSION': '2.1.37',
     'SERVE_INCLUDE_SCHEMA': True,
+    'SWAGGER_UI_DIST': 'SIDECAR',
+    'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
+    'REDOC_DIST': 'SIDECAR',
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ django-filter
 django-rest-knox
 rest-social-auth
 drf-spectacular
+drf-spectacular-sidecar
 requests-oauthlib
 cryptography


### PR DESCRIPTION
This pull request updates the API documentation tooling for the project by integrating the `drf_spectacular_sidecar` package and configuring the API documentation UI to use sidecar-provided static assets. These changes help ensure that the Swagger UI and Redoc documentation are served with up-to-date and self-contained frontend resources.

API documentation improvements:

* Added `drf_spectacular_sidecar` to the `INSTALLED_APPS` list in `CapX/settings.py` to enable serving static assets for API documentation UIs.
* Updated the `SPECTACULAR_SETTINGS` in `CapX/settings.py` to use sidecar-provided assets for Swagger UI and Redoc by setting `SWAGGER_UI_DIST`, `SWAGGER_UI_FAVICON_HREF`, and `REDOC_DIST` to `'SIDECAR'`.