### PR TITLE
Portal fix 2

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -168,7 +168,7 @@ REST_KNOX = {'TOKEN_TTL': timedelta(days=30)}
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Capacity Exchange (CapX) API',
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
-    'VERSION': '2.1.40',
+    'VERSION': '2.1.41',
     'SERVE_INCLUDE_SCHEMA': True,
     'SWAGGER_UI_DIST': 'SIDECAR',
     'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',

--- a/portal/templates/portal/dashboard.html
+++ b/portal/templates/portal/dashboard.html
@@ -111,20 +111,66 @@
         <thead>
           <tr>
             <th>Username</th>
-            <th>Role</th>
-            <th>Affiliation</th>
+            <th>Is staff</th>
+            <th>Is active</th>
             <th>Date joined</th>
+            <th>Last update</th>
             <th>Last login</th>
+            <th>Wikidata QID</th>
+            <th>Wiki alt</th>
+            <th>Territory</th>
+            <th>Language</th>
+            <th>Affiliation</th>
+            <th>Wikimedia project</th>
+            <th>Team</th>
+            <th>Skills known</th>
+            <th>Skills available</th>
+            <th>Skills wanted</th>
+            <th>Manager of organizations</th>
+            <th>Badges</th>
+            <th>Automated Lets Connect</th>
           </tr>
         </thead>
         <tbody>
           {% for row in users_table %}
             <tr>
               <td>{{ row.username }}</td>
-              <td>{{ row.role }}</td>
-              <td>{{ row.affiliation }}</td>
+              <td>{{ row.is_staff }}</td>
+              <td>{{ row.is_active }}</td>
               <td>{{ row.date_joined }}</td>
+              <td>{{ row.last_update }}</td>
               <td>{{ row.last_login }}</td>
+              <td>{{ row.wikidata_qid }}</td>
+              <td>{{ row.wiki_alt }}</td>
+              <td>{{ row.territory }}</td>
+              <td>
+                {% if row.language %}
+                  {% for lang in row.language %}
+                    {{ lang.name }} ({{ lang.proficiency }}){% if not forloop.last %}, {% endif %}
+                  {% endfor %}
+                {% endif %}
+              </td>
+              <td>{{ row.affiliation }}</td>
+              <td>{{ row.wikimedia_project }}</td>
+              <td>{{ row.team }}</td>
+              <td>{{ row.skills_known }}</td>
+              <td>{{ row.skills_available }}</td>
+              <td>{{ row.skills_wanted }}</td>
+              <td>
+                {% if row.is_manager %}
+                  {% for org_id in row.is_manager %}
+                    {{ org_id }}{% if not forloop.last %}, {% endif %}
+                  {% endfor %}
+                {% endif %}
+              </td>
+              <td>
+                {% if row.badges %}
+                  {% for badge_id in row.badges %}
+                    {{ badge_id }}{% if not forloop.last %}, {% endif %}
+                  {% endfor %}
+                {% endif %}
+              </td>
+              <td>{{ row.automated_lets_connect }}</td>
             </tr>
           {% endfor %}
         </tbody>
@@ -312,6 +358,32 @@
           });
         }
         buildColumnToggles();
+
+        // Auto-fit: hide columns from the right until the table fits the container
+        function hasHorizontalOverflow(container) {
+          return container.scrollWidth - container.clientWidth > 1; // tolerate 1px
+        }
+        function setToggleChecked(idx, checked) {
+          var cb = document.getElementById('toggle-col-' + idx);
+          if (cb) cb.checked = !!checked;
+        }
+        function autoFitColumns(minVisible) {
+          var container = table.closest('.card') || table.parentElement || document.body;
+          var min = (typeof minVisible === 'number' && minVisible > 0) ? minVisible : 5; // keep at least 5
+          // Early exit if no overflow
+          if (!hasHorizontalOverflow(container)) return;
+          // Iteratively hide the last visible column until it fits or we hit the minimum
+          var guard = 0; // safety to avoid infinite loops
+          while (hasHorizontalOverflow(container) && visibleColumnCount() > min && guard++ < headers.length) {
+            var visibleIdxs = getVisibleColumnIndexes();
+            if (!visibleIdxs.length) break;
+            var lastIdx = visibleIdxs[visibleIdxs.length - 1];
+            setColumnVisibility(lastIdx, false);
+            setToggleChecked(lastIdx, false);
+          }
+        }
+        // Run once after initial render
+        autoFitColumns(5);
 
         // CSV export (respects filter and visible columns)
         function getVisibleColumnIndexes() {

--- a/portal/views.py
+++ b/portal/views.py
@@ -12,7 +12,7 @@ from .models import PortalUser
 from social_django.utils import load_strategy, load_backend
 from users.submodels import AuthExtraInfo
 from django.views.decorators.http import require_GET, require_POST
-from users.models import CustomUser, Profile
+from users.models import CustomUser, Profile, UserBadge
 from knox.models import AuthToken
 
 DASHBOARD_URL_NAME = 'portal:dashboard'
@@ -72,42 +72,75 @@ def dashboard(request):
     orgs = Organization.objects.filter(managers=request.user).distinct()
     events = Events.objects.filter(organization__in=orgs).order_by('-time_begin')[:50]
 
-    # Build users table for all portal users
-    # Prefetch affiliations to avoid N+1 queries
-    all_users = (
-        CustomUser.objects.all()
-        .order_by('username')
-        .prefetch_related('profile__affiliation')
+    # Build users table to reflect ProfileSerializer/model fields used by the template
+    profiles = (
+        Profile.objects.select_related('user')
+        .prefetch_related(
+            'affiliation',
+            'territory',
+            'wikimedia_project',
+            'skills_known',
+            'skills_available',
+            'skills_wanted',
+            'languageproficiency_set__language',
+        )
+        .order_by('user__username')
     )
 
-    # Precompute manager user ids
-    manager_user_ids = set(Management.objects.values_list('user_id', flat=True))
+    # Prepare manager organization per user to avoid N+1
+    managers_map = {}
+    for uid, oname in Management.objects.select_related('organization').values_list('user_id', 'organization__display_name'):
+        managers_map.setdefault(uid, []).append(oname)
+
+    # Prepare displayed badges per user
+    user_ids = list(profiles.values_list('user_id', flat=True))
+    badges_map = {}
+    for uid, bname in UserBadge.objects.select_related('badge').filter(user_id__in=user_ids, is_displayed=True, progress=100).values_list('user_id', 'badge__name'):
+        badges_map.setdefault(uid, []).append(bname)
 
     users_table = []
-    for u in all_users:
-        # Determine role: Staff > Manager > User
-        if getattr(u, 'is_staff', False):
-            role = 'Staff'
-        elif u.id in manager_user_ids:
-            role = 'Manager'
-        else:
-            role = 'User'
+    for p in profiles:
+        u = p.user
 
-        # Affiliation names
-        affiliations = []
-        if hasattr(u, 'profile') and u.profile:
-            affiliations = [org.display_name for org in u.profile.affiliation.all()]
-
-        # Get last login from AuthToken
+        # Last login via Knox token
         last_token = AuthToken.objects.filter(user=u).order_by('-created').first()
         last_login = last_token.created if last_token else None
 
+        # String representations for multi-relations
+        aff_str = ', '.join([org.display_name for org in p.affiliation.all()]) if p.affiliation.exists() else ''
+        terr_str = ', '.join([t.territory_name for t in p.territory.all()]) if p.territory.exists() else ''
+        proj_str = ', '.join([wp.wikimedia_project_name for wp in p.wikimedia_project.all()]) if p.wikimedia_project.exists() else ''
+        skills_known_str = ', '.join([str(s) for s in p.skills_known.all()]) if p.skills_known.exists() else ''
+        skills_available_str = ', '.join([str(s) for s in p.skills_available.all()]) if p.skills_available.exists() else ''
+        skills_wanted_str = ', '.join([str(s) for s in p.skills_wanted.all()]) if p.skills_wanted.exists() else ''
+
+        # Languages (name + proficiency)
+        languages = [
+            {'name': getattr(lp.language, 'language_name', None) or str(lp.language), 'proficiency': lp.proficiency or '-'}
+            for lp in p.languageproficiency_set.all()
+        ]
+
         users_table.append({
+            # Top-level user fields
             'username': u.username,
-            'role': role,
-            'affiliation': ', '.join(affiliations) if affiliations else '',
+            'is_staff': u.is_staff,
+            'is_active': u.is_active,
             'date_joined': u.date_joined,
             'last_login': last_login,
+            'last_update': p.last_update,
+            'wikidata_qid': p.wikidata_qid,
+            'wiki_alt': p.wiki_alt,
+            'territory': terr_str,
+            'language': languages,
+            'affiliation': aff_str,
+            'wikimedia_project': proj_str,
+            'team': p.team,
+            'skills_known': skills_known_str,
+            'skills_available': skills_available_str,
+            'skills_wanted': skills_wanted_str,
+            'is_manager': managers_map.get(u.id, []),
+            'badges': badges_map.get(u.id, []),
+            'automated_lets_connect': p.automated_lets_connect,
         })
     context = {
         'user': request.user,


### PR DESCRIPTION
This pull request significantly expands and improves the user management dashboard in the portal by adding new user data fields, optimizing data fetching for performance, and enhancing the usability of the user table. The changes include both backend improvements to how user data is gathered and frontend updates to display more comprehensive information, along with a new auto-fit feature for the table columns.

**User Table Expansion and Data Handling:**

* The dashboard's user table now includes many additional fields such as staff and active status, last update, Wikidata QID, alternative wiki names, territory, languages (with proficiency), affiliations, Wikimedia projects, teams, skills (known, available, wanted), managed organizations, badges, and automated Lets Connect status. The backend logic in `portal/views.py` was refactored to efficiently gather and format all this data, avoiding N+1 queries and precomputing related fields for performance. [[1]](diffhunk://#diff-2dc257bdb2ded654df744d4da67b1b9c7664323b6a4729b88cf6d4919cb1e720L114-R173) [[2]](diffhunk://#diff-92efa686bbd6986f868bee56324849c3355df4024ec4cfff5f126354885e1a24L75-R143)

* The backend now uses the `Profile` model and related objects to build the user table, instead of just `CustomUser`, and adds efficient mapping for manager organizations and badges per user.

**Frontend Usability Improvements:**

* The user table in `dashboard.html` was updated to display all the new fields and to show multi-value fields (like languages, skills, affiliations, badges, and managed organizations) in a readable format.

* A new JavaScript function was added to automatically hide columns from the right until the table fits within its container, improving usability on smaller screens or when many columns are present.

**Other Minor Changes:**

* The API version was bumped from 2.1.40 to 2.1.41 in `settings.py` to reflect these updates.

* The `UserBadge` model was imported in `portal/views.py` to support badge display in the user table.