### PR TITLE
Add QID label resolution for skills and profiles in dashboard view

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -168,7 +168,7 @@ REST_KNOX = {'TOKEN_TTL': timedelta(days=30)}
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Capacity Exchange (CapX) API',
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
-    'VERSION': '2.1.41',
+    'VERSION': '2.1.42',
     'SERVE_INCLUDE_SCHEMA': True,
     'SWAGGER_UI_DIST': 'SIDECAR',
     'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',

--- a/portal/views.py
+++ b/portal/views.py
@@ -14,6 +14,7 @@ from users.submodels import AuthExtraInfo
 from django.views.decorators.http import require_GET, require_POST
 from users.models import CustomUser, Profile, UserBadge
 from knox.models import AuthToken
+import requests
 
 DASHBOARD_URL_NAME = 'portal:dashboard'
 
@@ -87,6 +88,55 @@ def dashboard(request):
         .order_by('user__username')
     )
 
+    # Resolve Wikidata QIDs to English labels using Metabase SPARQL
+    def fetch_qid_labels(qids):
+        qids = [q for q in qids if q]
+        if not qids:
+            return {}
+        try:
+            values = ' '.join(f'"{q}"' for q in sorted(set(qids)))
+            query = (
+                """
+                PREFIX wbt: <https://metabase.wikibase.cloud/prop/direct/>
+                SELECT ?item ?itemLabel ?itemDescription ?value WHERE {
+                    VALUES ?value { %s }
+                    ?item wbt:P1 ?value.
+                    SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+                }
+                """ % values
+            )
+            resp = requests.get(
+                'https://metabase.wikibase.cloud/query/sparql',
+                params={'query': query, 'format': 'json'},
+                headers={'User-Agent': 'CapX-Portal/1.0'}
+            )
+            data = resp.json()
+            mapping = {}
+            for row in data.get('results', {}).get('bindings', []):
+                val = row.get('value', {}).get('value')
+                label = row.get('itemLabel', {}).get('value')
+                if val and label:
+                    mapping[val] = label
+            return mapping
+        except Exception:
+            return {}
+
+    qid_labels = fetch_qid_labels(list(profiles.values_list('wikidata_qid', flat=True)))
+
+    # Collect all skill QIDs across profiles and resolve labels
+    skill_qids = set()
+    for p in profiles:
+        for s in p.skills_known.all():
+            if s.skill_wikidata_item:
+                skill_qids.add(s.skill_wikidata_item)
+        for s in p.skills_available.all():
+            if s.skill_wikidata_item:
+                skill_qids.add(s.skill_wikidata_item)
+        for s in p.skills_wanted.all():
+            if s.skill_wikidata_item:
+                skill_qids.add(s.skill_wikidata_item)
+    skill_labels = fetch_qid_labels(list(skill_qids))
+
     # Prepare manager organization per user to avoid N+1
     managers_map = {}
     for uid, oname in Management.objects.select_related('organization').values_list('user_id', 'organization__display_name'):
@@ -110,9 +160,9 @@ def dashboard(request):
         aff_str = ', '.join([org.display_name for org in p.affiliation.all()]) if p.affiliation.exists() else ''
         terr_str = ', '.join([t.territory_name for t in p.territory.all()]) if p.territory.exists() else ''
         proj_str = ', '.join([wp.wikimedia_project_name for wp in p.wikimedia_project.all()]) if p.wikimedia_project.exists() else ''
-        skills_known_str = ', '.join([str(s) for s in p.skills_known.all()]) if p.skills_known.exists() else ''
-        skills_available_str = ', '.join([str(s) for s in p.skills_available.all()]) if p.skills_available.exists() else ''
-        skills_wanted_str = ', '.join([str(s) for s in p.skills_wanted.all()]) if p.skills_wanted.exists() else ''
+        skills_known_str = ', '.join([skill_labels.get(s.skill_wikidata_item, s.skill_wikidata_item) for s in p.skills_known.all()]) if p.skills_known.exists() else ''
+        skills_available_str = ', '.join([skill_labels.get(s.skill_wikidata_item, s.skill_wikidata_item) for s in p.skills_available.all()]) if p.skills_available.exists() else ''
+        skills_wanted_str = ', '.join([skill_labels.get(s.skill_wikidata_item, s.skill_wikidata_item) for s in p.skills_wanted.all()]) if p.skills_wanted.exists() else ''
 
         # Languages (name + proficiency)
         languages = [
@@ -129,6 +179,7 @@ def dashboard(request):
             'last_login': last_login,
             'last_update': p.last_update,
             'wikidata_qid': p.wikidata_qid,
+            'wikidata_label': qid_labels.get(p.wikidata_qid),
             'wiki_alt': p.wiki_alt,
             'territory': terr_str,
             'language': languages,


### PR DESCRIPTION
This pull request enhances the user dashboard in `portal/views.py` by resolving Wikidata QIDs to their corresponding English labels using Metabase's SPARQL endpoint. This makes the display of user and skill information more readable and user-friendly. The most important changes are grouped below:

**Integration of Wikidata label resolution:**

* Added a helper function `fetch_qid_labels` that queries the Metabase SPARQL endpoint to resolve Wikidata QIDs to English labels, improving data presentation for users and skills.
* Included the `requests` library import to enable HTTP requests for SPARQL queries.

**Improved dashboard display:**

* Updated the construction of skill strings (`skills_known_str`, `skills_available_str`, `skills_wanted_str`) to use resolved labels from Wikidata, falling back to the QID if no label is found.
* Added a new field `wikidata_label` to each user profile in the dashboard context, showing the resolved label for the user's Wikidata QID.