### PR TITLE
Update date formatting in dashboard to Y-m-d H:i:s

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -168,7 +168,7 @@ REST_KNOX = {'TOKEN_TTL': timedelta(days=30)}
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Capacity Exchange (CapX) API',
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
-    'VERSION': '2.1.46',
+    'VERSION': '2.1.47',
     'SERVE_INCLUDE_SCHEMA': True,
     'SWAGGER_UI_DIST': 'SIDECAR',
     'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',

--- a/portal/templates/portal/dashboard.html
+++ b/portal/templates/portal/dashboard.html
@@ -283,9 +283,9 @@
                 <td>
                   <span class="pill {{ row.is_active|yesno:'pill--success,pill--danger' }}">{{ row.is_active|yesno:'Active,Inactive' }}</span>
                 </td>
-                <td>{{ row.date_joined|date:"c" }}</td>
-                <td>{{ row.last_update|date:"c" }}</td>
-                <td>{{ row.last_login|date:"c" }}</td>
+                <td>{{ row.date_joined|date:"Y-m-d H:i:s" }}</td>
+                <td>{{ row.last_update|date:"Y-m-d H:i:s" }}</td>
+                <td>{{ row.last_login|date:"Y-m-d H:i:s" }}</td>
                 <td>{{ row.wikidata_qid }}</td>
                 <td>{{ row.wiki_alt }}</td>
                 <td>{{ row.territory }}</td>
@@ -422,7 +422,7 @@
               <tr>
                 <td>{{ pu.user.username }}</td>
                 <td>{{ pu.partner.name }}</td>
-                <td>{{ pu.created_at|date:"c" }}</td>
+                <td>{{ pu.created_at|date:"Y-m-d H:i:s" }}</td>
               </tr>
             {% empty %}
               <tr><td colspan="6" class="muted">No records.</td></tr>


### PR DESCRIPTION
This pull request makes minor updates to the CapX platform, primarily focused on improving the readability of date and time fields in the dashboard templates and updating the API version.

Dashboard date formatting improvements:

* Updated date formatting in the `portal/templates/portal/dashboard.html` file to display dates in the more human-readable `"Y-m-d H:i:s"` format instead of the ISO 8601 `"c"` format for fields such as `date_joined`, `last_update`, `last_login`, and `created_at`. [[1]](diffhunk://#diff-2dc257bdb2ded654df744d4da67b1b9c7664323b6a4729b88cf6d4919cb1e720L286-R288) [[2]](diffhunk://#diff-2dc257bdb2ded654df744d4da67b1b9c7664323b6a4729b88cf6d4919cb1e720L425-R425)

General maintenance:

* Bumped the CapX API version from `2.1.46` to `2.1.47` in `CapX/settings.py`.