### PR TITLE
Recomm

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -168,7 +168,7 @@ REST_KNOX = {'TOKEN_TTL': timedelta(days=30)}
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Capacity Exchange (CapX) API',
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
-    'VERSION': '2.1.46',
+    'VERSION': '2.1.47',
     'SERVE_INCLUDE_SCHEMA': True,
     'SWAGGER_UI_DIST': 'SIDECAR',
     'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',

--- a/portal/templates/portal/dashboard.html
+++ b/portal/templates/portal/dashboard.html
@@ -283,9 +283,9 @@
                 <td>
                   <span class="pill {{ row.is_active|yesno:'pill--success,pill--danger' }}">{{ row.is_active|yesno:'Active,Inactive' }}</span>
                 </td>
-                <td>{{ row.date_joined|date:"c" }}</td>
-                <td>{{ row.last_update|date:"c" }}</td>
-                <td>{{ row.last_login|date:"c" }}</td>
+                <td>{{ row.date_joined|date:"Y-m-d H:i:s" }}</td>
+                <td>{{ row.last_update|date:"Y-m-d H:i:s" }}</td>
+                <td>{{ row.last_login|date:"Y-m-d H:i:s" }}</td>
                 <td>{{ row.wikidata_qid }}</td>
                 <td>{{ row.wiki_alt }}</td>
                 <td>{{ row.territory }}</td>
@@ -422,7 +422,7 @@
               <tr>
                 <td>{{ pu.user.username }}</td>
                 <td>{{ pu.partner.name }}</td>
-                <td>{{ pu.created_at|date:"c" }}</td>
+                <td>{{ pu.created_at|date:"Y-m-d H:i:s" }}</td>
               </tr>
             {% empty %}
               <tr><td colspan="6" class="muted">No records.</td></tr>

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -180,6 +180,21 @@ class UsersByTagSerializer(serializers.ModelSerializer):
             'profile_image'
         ]
 
+
+class RecommendationUserSerializer(serializers.ModelSerializer):
+    username = serializers.CharField(source='user.username')
+    matches = serializers.IntegerField(source='match_count')
+
+    class Meta:
+        model = Profile
+        fields = [
+            'id',
+            'display_name',
+            'username',
+            'profile_image',
+            'matches',
+        ]
+
 @extend_schema_field({
     'type': 'integer',
     'description': 'ID of the organization or user',

--- a/users/views.py
+++ b/users/views.py
@@ -1,6 +1,6 @@
 from .models import Profile, Territory, Language, WikimediaProject, Avatar, SavedItem, Badge, UserBadge
 from orgs.models import Organization
-from .serializers import ProfileSerializer, TerritorySerializer, LanguageSerializer, WikimediaProjectSerializer, UsersBySkillSerializer, UsersByTagSerializer, AvatarSerializer, SavedItemSerializer, BadgeSerializer, UserBadgeSerializer
+from .serializers import ProfileSerializer, TerritorySerializer, LanguageSerializer, WikimediaProjectSerializer, UsersBySkillSerializer, UsersByTagSerializer, AvatarSerializer, SavedItemSerializer, BadgeSerializer, UserBadgeSerializer, RecommendationUserSerializer
 from skills.models import Skill
 from events.models import Events
 from projects.models import Project
@@ -791,22 +791,52 @@ class RecommendationView(APIView):
         all_user_skill_ids = skills_known_ids | skills_available_ids | skills_wanted_ids
 
         # People to share skills with: others who want what I can teach
-        share_with_qs = Profile.objects.filter(
-            skills_wanted__id__in=list(skills_available_ids)
-        ).exclude(pk=profile.pk).distinct()[:limit]
+        share_with_qs = (
+            Profile.objects.exclude(pk=profile.pk)
+            .annotate(
+                match_count=Count(
+                    'skills_wanted',
+                    filter=models.Q(skills_wanted__id__in=list(skills_available_ids)),
+                    distinct=True,
+                )
+            )
+            .filter(match_count__gt=0)
+            .order_by('-match_count', '?')[:limit]
+        )
 
         # People to learn from: others who can teach what I want
-        learn_from_qs = Profile.objects.filter(
-            skills_available__id__in=list(skills_wanted_ids)
-        ).exclude(pk=profile.pk).distinct()[:limit]
+        learn_from_qs = (
+            Profile.objects.exclude(pk=profile.pk)
+            .annotate(
+                match_count=Count(
+                    'skills_available',
+                    filter=models.Q(skills_available__id__in=list(skills_wanted_ids)),
+                    distinct=True,
+                )
+            )
+            .filter(match_count__gt=0)
+            .order_by('-match_count', '?')[:limit]
+        )
 
-        # Same language people: share any language (exclude proficiency 0)
+        # Same language people: rank by number of shared languages (exclude proficiency 0), randomize ties
         lang_ids = list(
             profile.languageproficiency_set.exclude(proficiency=0).values_list('language_id', flat=True)
         )
-        same_lang_qs = Profile.objects.filter(
-            languageproficiency__language_id__in=lang_ids
-        ).exclude(languageproficiency__proficiency=0).exclude(pk=profile.pk).distinct()[:limit]
+        same_lang_qs = (
+            Profile.objects.exclude(pk=profile.pk)
+            .annotate(
+                match_count=Count(
+                    'languageproficiency',
+                    filter=(
+                        models.Q(languageproficiency__language_id__in=lang_ids)
+                        & ~models.Q(languageproficiency__proficiency=0)
+                    ),
+                    distinct=True,
+                )
+            )
+            .filter(match_count__gt=0)
+            .order_by('-match_count', '?')[:limit]
+        )
 
         # New skills: popular skills the user doesn't have/want yet
         new_skills_qs = (
@@ -816,7 +846,7 @@ class RecommendationView(APIView):
                 available_count=Count('user_available_skills', distinct=True),
             )
             .annotate(popularity=F('known_count') + F('available_count'))
-            .order_by('-popularity', 'id')[:limit]
+            .order_by('-popularity', '?')[:limit]
         )
 
         # Events: upcoming events related to my skills
@@ -830,14 +860,13 @@ class RecommendationView(APIView):
         )
 
         # Serialize
-        users_serializer = UsersByTagSerializer
         from skills.serializers import SkillSerializer  # local import to avoid cycles
         from events.serializers import EventSerializer
 
         data = {
-            'share_with': users_serializer(share_with_qs, many=True).data,
-            'learn_from': users_serializer(learn_from_qs, many=True).data,
-            'same_language': users_serializer(same_lang_qs, many=True).data,
+            'share_with': RecommendationUserSerializer(share_with_qs, many=True).data,
+            'learn_from': RecommendationUserSerializer(learn_from_qs, many=True).data,
+            'same_language': RecommendationUserSerializer(same_lang_qs, many=True).data,
             'new_skills': SkillSerializer(new_skills_qs, many=True).data,
             'events': EventSerializer(events_qs, many=True).data,
         }


### PR DESCRIPTION
This pull request introduces improvements to the user recommendation logic and display formatting, particularly around matching users for skill sharing and language. The most significant changes are the enhancement of the recommendation algorithm to rank users by the number of shared skills or languages, and the addition of a new serializer to expose this match count in API responses. 

**User recommendation improvements:**

* Enhanced the recommendation queries in `users/views.py` to rank recommended users (`share_with`, `learn_from`, and `same_language`) by the number of matching skills or languages, and randomize ties, improving the relevance of suggestions.
* Added a new `RecommendationUserSerializer` in `users/serializers.py` to include a `matches` field (number of shared skills/languages) in the API response, and updated the view to use this serializer for recommendations. [[1]](diffhunk://#diff-4349bb2be4e3bfa15b93d2cf390f4df197e2a0b11e6edfe8abd3f09beec21273R183-R197) [[2]](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47L3-R3) [[3]](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47L833-R869)

**Other:**

* Bumped the API version in `CapX/settings.py` from `2.1.46` to `2.1.47`.
* Adjusted the ordering of new skill recommendations to randomize ties when popularity is equal.