### PR TITLE
Recommendations: ignore saved profiles

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -168,7 +168,7 @@ REST_KNOX = {'TOKEN_TTL': timedelta(days=30)}
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Capacity Exchange (CapX) API',
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
-    'VERSION': '2.1.48',
+    'VERSION': '2.1.49',
     'SERVE_INCLUDE_SCHEMA': True,
     'SWAGGER_UI_DIST': 'SIDECAR',
     'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',

--- a/users/views.py
+++ b/users/views.py
@@ -773,6 +773,13 @@ class RecommendationView(APIView):
                 required=False,
                 type=OpenApiTypes.INT,
             ),
+            OpenApiParameter(
+                name='ignore_saved',
+                description='When true, ignore users and organizations the requester has saved (default: true).',
+                required=False,
+                type=OpenApiTypes.BOOL,
+                default=True,
+            ),
         ],
         responses={(200, 'application/json'): {
             'type': 'object',
@@ -809,6 +816,22 @@ class RecommendationView(APIView):
             limit = 10
         limit = max(1, min(limit, 50))
 
+        # Whether to ignore already-saved users/orgs (default True)
+        ignore_saved_param = str(request.query_params.get('ignore_saved', 'true')).lower()
+        ignore_saved = ignore_saved_param not in ('false', '0', 'no')
+
+        saved_user_ids = []
+        saved_org_ids = []
+        if ignore_saved:
+            saved_user_ids = list(
+                SavedItem.objects.filter(user=user, entity='user')
+                .values_list('related_user_id', flat=True)
+            )
+            saved_org_ids = list(
+                SavedItem.objects.filter(user=user, entity='org')
+                .values_list('related_org_id', flat=True)
+            )
+
         # Collect user's skills
         skills_known_ids = set(profile.skills_known.values_list('id', flat=True))
         skills_available_ids = set(profile.skills_available.values_list('id', flat=True))
@@ -818,6 +841,7 @@ class RecommendationView(APIView):
         # People to share skills with: others who want what I can teach
         share_with_qs = (
             Profile.objects.exclude(pk=profile.pk)
+            .exclude(user__id__in=saved_user_ids)
             .annotate(
                 match_count=Count(
                     'skills_wanted',
@@ -832,6 +856,7 @@ class RecommendationView(APIView):
         # People to learn from: others who can teach what I want
         learn_from_qs = (
             Profile.objects.exclude(pk=profile.pk)
+            .exclude(user__id__in=saved_user_ids)
             .annotate(
                 match_count=Count(
                     'skills_available',
@@ -849,6 +874,7 @@ class RecommendationView(APIView):
         )
         same_lang_qs = (
             Profile.objects.exclude(pk=profile.pk)
+            .exclude(user__id__in=saved_user_ids)
             .annotate(
                 match_count=Count(
                     'languageproficiency',
@@ -887,6 +913,7 @@ class RecommendationView(APIView):
         # Organizations to share skills with: organizations that want what I can teach
         share_with_orgs_qs = (
             Organization.objects.filter(managers__isnull=False)
+            .exclude(id__in=saved_org_ids)
             .annotate(
                 match_count=Count(
                     'wanted_capacities',
@@ -901,6 +928,7 @@ class RecommendationView(APIView):
         # Organizations to learn from: organizations that can teach what I want
         learn_from_orgs_qs = (
             Organization.objects.filter(managers__isnull=False)
+            .exclude(id__in=saved_org_ids)
             .annotate(
                 match_count=Count(
                     'available_capacities',


### PR DESCRIPTION
This pull request adds a new feature to the recommendations API, allowing users to exclude people and organizations they have already saved from their recommendations. By default, saved users and organizations are ignored in the results, but this can be controlled via a new query parameter. The changes also update the API documentation and increment the API version.

**Recommendations filtering improvements:**

* Added a new `ignore_saved` query parameter (default: true) to the recommendations endpoint, allowing users to choose whether to exclude saved users and organizations from their recommendations. The API documentation for this endpoint has been updated to describe the new parameter.
* Implemented logic to filter out users and organizations that the requester has previously saved when `ignore_saved` is enabled, affecting all relevant recommendation queries for both users and organizations. [[1]](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47R819-R834) [[2]](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47R844) [[3]](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47R859) [[4]](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47R877) [[5]](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47R916) [[6]](diffhunk://#diff-e559aa8a09e3a05a27fa6fcef98aafbd888877551a23cf23ca4ee8e08ab97e47R931)

**Version update:**

* Bumped the API version from `2.1.48` to `2.1.49` in `CapX/settings.py` to reflect the new functionality.