### PR TITLE
Implement DatabaseErrorMiddleware for improved DB error handling

### DIFF
--- a/CapX/middlewares.py
+++ b/CapX/middlewares.py
@@ -1,5 +1,68 @@
-from django.db.utils import OperationalError
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpResponse
+from django.db.utils import OperationalError, InterfaceError, DatabaseError
+from django.db import connection
+
+
+def _is_service_unavailable_db_error(exc: BaseException) -> bool:
+    """
+    Decide if the exception should be surfaced as a 503 Service Unavailable due to DB issues,
+    without having to enumerate every possible PyMySQL error message.
+
+    Strategy:
+    - Catch broad django DB errors (OperationalError/InterfaceError/DatabaseError).
+    - If an error code is present and is a well-known transient/connection code, treat as 503.
+      Keep the set small to avoid overfitting.
+    - Otherwise, ping the connection using connection.is_usable(). If ping fails or raises,
+      treat it as a DB outage and return 503. This avoids message parsing.
+    """
+
+    if not isinstance(exc, (OperationalError, InterfaceError, DatabaseError)):
+        return False
+
+    code = None
+    if getattr(exc, "args", None):
+        first = exc.args[0]
+        if isinstance(first, int):
+            code = first
+
+    # Minimal, focused set of transient/connection-oriented MySQL codes:
+    # 2002: Connection refused; 2003: Can't connect; 2006: Server gone away; 2013: Lost connection
+    # 1205: Lock wait timeout; 1213: Deadlock found
+    transient_or_conn = {2002, 2003, 2006, 2013, 1205, 1213}
+    if code in transient_or_conn:
+        return True
+
+    # Fallback: if the connection isn't usable (ping fails), treat as service unavailable
+    try:
+        usable = connection.is_usable()
+    except Exception:
+        # If the ping itself raises, we consider the DB unavailable
+        return True
+    return not usable
+
+
+def _service_unavailable_response(request, detail: str, message: str):
+    accept = request.META.get("HTTP_ACCEPT", "")
+    wants_html = "text/html" in accept and "application/json" not in accept and not request.path.startswith("/api")
+    if wants_html:
+        resp = HttpResponse(
+            "<h1>Service temporarily unavailable</h1>"
+            "<p>The database is temporarily unavailable. Please try again later.</p>",
+            status=503,
+            content_type="text/html",
+        )
+        resp["Retry-After"] = "60"
+        return resp
+    resp = JsonResponse(
+        {
+            "detail": "Toolforge' database is not available at the moment. Please try again later.",
+            "message": message,
+        },
+        status=503,
+    )
+    resp["Retry-After"] = "60"
+    return resp
+
 
 class DatabaseErrorMiddleware:
     def __init__(self, get_response):
@@ -8,14 +71,12 @@ class DatabaseErrorMiddleware:
     def __call__(self, request):
         try:
             return self.get_response(request)
-        except OperationalError as e:
-            error_message = str(e)
-            if "Can't connect to MySQL server" in error_message:
-                return JsonResponse(
-                    {
-                        "detail": "Toolforge' database is not available at the moment. Please try again later.",
-                        "message": error_message
-                    },
-                    status=503
-                )
+        except Exception as exc:
+            if _is_service_unavailable_db_error(exc):
+                return _service_unavailable_response(request, "DB unavailable", str(exc))
             raise
+
+    def process_exception(self, request, exception):
+        if _is_service_unavailable_db_error(exception):
+            return _service_unavailable_response(request, "DB unavailable", str(exception))
+        return None

--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'CapX.middlewares.DatabaseErrorMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -55,7 +56,6 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
-    'CapX.middlewares.DatabaseErrorMiddleware',
 ]
 
 ROOT_URLCONF = 'CapX.urls'


### PR DESCRIPTION
This pull request refactors and improves the handling of database errors in the Django middleware for the `CapX` project. The main focus is to robustly detect database outages and return appropriate HTTP 503 Service Unavailable responses, with better differentiation between HTML and JSON clients. The changes also update middleware configuration to ensure correct ordering and avoid duplicate entries.

**Database error handling improvements:**

* Added the `_is_service_unavailable_db_error` helper function to reliably detect transient or connection-related database errors using error codes and connection health checks, instead of relying on error message parsing.
* Introduced the `_service_unavailable_response` helper to return a tailored 503 response in either HTML or JSON format, depending on the client's `Accept` header and request path.
* Refactored `DatabaseErrorMiddleware` to use the new helper functions, improving error detection and response generation for both normal request handling and exception processing.

**Middleware configuration updates:**

* Moved `CapX.middlewares.DatabaseErrorMiddleware` to the top of the `MIDDLEWARE` list in `CapX/settings.py` for correct error interception, and removed its duplicate entry at the end of the list. [[1]](diffhunk://#diff-6f9b02506e9090171d696773b3cca52c9ee9c89a1cd88bb5c4a4c97b5deee942R49) [[2]](diffhunk://#diff-6f9b02506e9090171d696773b3cca52c9ee9c89a1cd88bb5c4a4c97b5deee942L58)