### PR TITLE
Add localized capacities fetching to export command

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -58,7 +58,7 @@ jobs:
         coverage report
         coverage xml
     - name: SonarCloud Scan
-      uses: SonarSource/sonarcloud-github-action@master
+      uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -14,17 +14,17 @@ jobs:
       matrix:
         python-version: [3.10.16]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       with:
         fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-    - uses: getong/mariadb-action@v1.11
+    - uses: getong/mariadb-action@d6d2ec41fd5588f369be4c9398ce77ee725ca9ea
       with:
         mariadb version: '10.6.21'
         mysql user: 'runner'
         mysql password: 'runner'
         mysql database: 'test'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run deployment script
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@91f3272fc5907f4699dcf59761eb622a07342f5a
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}

--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -168,7 +168,7 @@ REST_KNOX = {'TOKEN_TTL': timedelta(days=30)}
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Capacity Exchange (CapX) API',
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
-    'VERSION': '2.1.49',
+    'VERSION': '2.1.50',
     'SERVE_INCLUDE_SCHEMA': True,
     'SWAGGER_UI_DIST': 'SIDECAR',
     'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',

--- a/users/management/commands/export.py
+++ b/users/management/commands/export.py
@@ -172,6 +172,92 @@ class Command(BaseCommand):
             self.stdout.write(f"SPARQL response data: {formatted_data}")
         return formatted_data
 
+    def fetch_localized_capacities(self, quids):
+        """
+        Fetch localized labels and descriptions from Metabase for given QIDs.
+        Returns a mapping: { qid: { lang: { 'label': str|None, 'description': str|None } } }
+        """
+        quids = [q for q in quids if q]
+        if not quids:
+            return {}
+        item_ids = " ".join(f"'{qid}'" for qid in quids)
+        query = f"""PREFIX wbt:<https://metabase.wikibase.cloud/prop/direct/>
+            PREFIX wb: <https://metabase.wikibase.cloud/entity/>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+            PREFIX schema: <http://schema.org/>
+            SELECT ?item ?value ?language (SAMPLE(?label) AS ?label) (SAMPLE(?description) AS ?description) WHERE {{  
+                VALUES ?value {{ {item_ids} }}
+                ?item wbt:P5 wb:Q34531.
+                ?item wbt:P67/wbt:P1 ?value.  
+                {{
+                    ?item rdfs:label ?label.
+                    BIND(LANG(?label) AS ?language)
+                }}
+                UNION
+                {{
+                    ?item schema:description ?description.
+                    BIND(LANG(?description) AS ?language)
+                }}
+            }}
+            GROUP BY ?item ?value ?language
+            ORDER BY ?language
+            """
+        headers = {'User-Agent': self.get_user_agent(), 'Accept': 'application/sparql-results+json'}
+        response = requests.get(
+            'https://metabase.wikibase.cloud/query/sparql',
+            params={'query': query},
+            headers=headers,
+            timeout=60,
+        )
+        response.raise_for_status()
+        data = response.json()
+        if self.verbosity >= 2:
+            self.stdout.write(f"Localized capacities SPARQL rows: {len(data.get('results', {}).get('bindings', []))}")
+        localized: dict[str, dict[str, dict[str, str | None]]] = {}
+        for b in data.get('results', {}).get('bindings', []):
+            qid = b.get('value', {}).get('value')
+            lang = b.get('language', {}).get('value')
+            label = b.get('label', {}).get('value')
+            description = b.get('description', {}).get('value')
+            if not qid or not lang:
+                continue
+            entry = localized.setdefault(qid, {}).setdefault(lang, {'label': None, 'description': None})
+            if label is not None:
+                entry['label'] = label
+            if description is not None:
+                entry['description'] = description
+        # Enforce max length per localized string (truncate to 397 + '...')
+        MAX_LEN = 400
+        ELLIPSIS = '...'
+        TRUNC_LEN = MAX_LEN - len(ELLIPSIS)
+        for qid, lang_map in localized.items():
+            for lang, vals in lang_map.items():
+                for field in ('label', 'description'):
+                    v = vals.get(field)
+                    if v and len(v) > MAX_LEN:
+                        vals[field] = v[:TRUNC_LEN].rstrip() + ELLIPSIS
+                        if self.verbosity >= 2:
+                            self.stdout.write(f"Truncated {field} for {qid}/{lang} to {MAX_LEN} chars")
+        if self.verbosity >= 2:
+            self.stdout.write(f"Localized capacities map keys (qids): {list(localized.keys())}")
+        return localized
+
+    def build_localized_capacities_rows(self, quids, skill_dict, localized_terms):
+        """
+        Build rows: [id, {lang: label}, {lang: description}, qid]
+        """
+        rows = []
+        # stable order by Skill id when possible
+        for qid in sorted(skill_dict.keys(), key=lambda q: skill_dict[q]):
+            sid = skill_dict[qid]
+            langs = localized_terms.get(qid, {})
+            name_obj = {lang: terms['label'] for lang, terms in langs.items() if terms.get('label')}
+            desc_obj = {lang: terms['description'] for lang, terms in langs.items() if terms.get('description')}
+            rows.append([sid, name_obj, desc_obj, qid])
+        if self.verbosity >= 2:
+            self.stdout.write(f"Localized capacities rows built: {len(rows)}")
+        return rows
+
     def create_output_users(self, formatted_data):
         output_users = {
             "license": "CC0-1.0",
@@ -199,8 +285,8 @@ class Command(BaseCommand):
             "schema": {
                 "fields": [
                     {"name": "id", "type": "number"},
-                    {"name": "name", "type": "string"},
-                    {"name": "description", "type": "string"},
+                    {"name": "name", "type": "localized"},
+                    {"name": "description", "type": "localized"},
                     {"name": "wikidata_item", "type": "string"}
                 ],
             },
@@ -322,14 +408,10 @@ class Command(BaseCommand):
 
         skill_dict = self.get_skill_dict(skills)
         quids = list(skill_dict.keys())
-        sparql_query = self.get_sparql_query(quids)
-        response = requests.get(
-            'https://metabase.wikibase.cloud/query/sparql',
-            params={'query': sparql_query, 'format': 'json'},
-            headers={'User-Agent': self.get_user_agent()}
-        )
-        formatted_data = self.process_sparql_response(response, skill_dict)
-        output_capacities = self.create_output_capacities(formatted_data)
+        # Fetch all localized terms for capacities in one go and build localized rows
+        localized_terms = self.fetch_localized_capacities(quids)
+        capacities_rows = self.build_localized_capacities_rows(quids, skill_dict, localized_terms)
+        output_capacities = self.create_output_capacities(capacities_rows)
         output_badges = self.create_output_badges(badges_meta)
 
         # Hash current data

--- a/users/tests/test_export.py
+++ b/users/tests/test_export.py
@@ -158,7 +158,7 @@ class CommandTestCase(TestCase):
         self.assertEqual(result, expected_output)
 
     def test_create_output_capacities(self):
-        formatted_data = [[1, 'Skill1', 'Description1']]
+        formatted_data = [[1, {"en": "Skill1"}, {"en": "Description1"}, "Q1"]]
         result = self.command.create_output_capacities(formatted_data)
         expected_output = {
             "license": "CC0-1.0",
@@ -167,8 +167,8 @@ class CommandTestCase(TestCase):
             "schema": {
                 "fields": [
                     {"name": "id", "type": "number"},
-                    {"name": "name", "type": "string"},
-                    {"name": "description", "type": "string"},
+                    {"name": "name", "type": "localized"},
+                    {"name": "description", "type": "localized"},
                     {"name": "wikidata_item", "type": "string"}
                 ],
             },
@@ -347,8 +347,8 @@ class CommandTestCase(TestCase):
              patch('users.management.commands.export.Command.process_profiles') as mock_process_profiles, \
              patch('users.management.commands.export.Command.create_output_users') as mock_create_output_users, \
              patch('users.management.commands.export.Command.get_skill_dict') as mock_get_skill_dict, \
-             patch('users.management.commands.export.Command.get_sparql_query') as mock_get_sparql_query, \
-             patch('users.management.commands.export.Command.process_sparql_response') as mock_process_sparql_response, \
+             patch('users.management.commands.export.Command.fetch_localized_capacities') as mock_fetch_localized_capacities, \
+             patch('users.management.commands.export.Command.build_localized_capacities_rows') as mock_build_localized_capacities_rows, \
              patch('users.management.commands.export.Command.create_output_capacities') as mock_create_output_capacities, \
              patch('users.management.commands.export.Command.create_output_badges') as mock_create_output_badges, \
              patch('users.management.commands.export.Command.get_login_token') as mock_get_login_token, \
@@ -362,9 +362,8 @@ class CommandTestCase(TestCase):
             mock_process_profiles.return_value = ([], [], [])
             mock_create_output_users.return_value = {}
             mock_get_skill_dict.return_value = {}
-            mock_get_sparql_query.return_value = 'sparql_query'
-            mock_requests_get.return_value.json.return_value = {'results': {'bindings': []}}
-            mock_process_sparql_response.return_value = []
+            mock_fetch_localized_capacities.return_value = {}
+            mock_build_localized_capacities_rows.return_value = []
             mock_create_output_capacities.return_value = {}
             mock_create_output_badges.return_value = {}
             mock_get_login_token.return_value = 'test_login_token'
@@ -381,15 +380,56 @@ class CommandTestCase(TestCase):
             mock_process_profiles.assert_called_once()
             mock_create_output_users.assert_called_once()
             mock_get_skill_dict.assert_called_once()
-            mock_get_sparql_query.assert_called_once()
-            mock_requests_get.assert_called_once()
-            mock_process_sparql_response.assert_called_once()
+            mock_fetch_localized_capacities.assert_called_once()
+            mock_build_localized_capacities_rows.assert_called_once()
             mock_create_output_capacities.assert_called_once()
             mock_create_output_badges.assert_called_once()
             mock_get_login_token.assert_called_once()
             mock_login.assert_called_once()
             mock_get_csrf_token.assert_called()
             mock_edit_page.assert_called()
+
+    def test_build_localized_capacities_rows(self):
+        skill_dict = {'Q1': 10, 'Q2': 2}
+        localized_terms = {
+            'Q1': {'en': {'label': 'Alpha', 'description': 'Desc Alpha'}, 'fr': {'label': 'Alpha FR', 'description': None}},
+            'Q2': {'en': {'label': 'Beta', 'description': 'Desc Beta'}}
+        }
+        rows = self.command.build_localized_capacities_rows(list(skill_dict.keys()), skill_dict, localized_terms)
+        # Order by Skill id (2 then 10) -> Q2 then Q1
+        self.assertEqual(rows[0][0], 2)
+        self.assertEqual(rows[0][1], {'en': 'Beta'})
+        self.assertEqual(rows[0][2], {'en': 'Desc Beta'})
+        self.assertEqual(rows[0][3], 'Q2')
+        self.assertEqual(rows[1][0], 10)
+        self.assertEqual(rows[1][1], {'en': 'Alpha', 'fr': 'Alpha FR'})
+        self.assertEqual(rows[1][2], {'en': 'Desc Alpha'})
+        self.assertEqual(rows[1][3], 'Q1')
+
+    @patch('users.management.commands.export.requests.get')
+    def test_fetch_localized_capacities_truncation(self, mock_get):
+        long_text = 'A' * 405
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'results': {
+                'bindings': [
+                    {
+                        'value': {'value': 'Q1'},
+                        'language': {'value': 'en'},
+                        'label': {'value': long_text},
+                        'description': {'value': long_text}
+                    }
+                ]
+            }
+        }
+        mock_get.return_value = mock_response
+        res = self.command.fetch_localized_capacities(['Q1'])
+        self.assertIn('Q1', res)
+        en = res['Q1']['en']
+        self.assertTrue(len(en['label']) <= 400)
+        self.assertTrue(en['label'].endswith('...'))
+        self.assertTrue(len(en['description']) <= 400)
+        self.assertTrue(en['description'].endswith('...'))
 
 class AddArgumentsTestCase(TestCase):
     def test_add_arguments_dry_run(self):


### PR DESCRIPTION
This pull request introduces support for localized labels and descriptions for capacities in the export process. It adds new methods to fetch and build localized capacity data, updates the schema to reflect the new localized fields, and adjusts the tests to cover these changes. The main impact is that capacity names and descriptions are now provided per language, improving internationalization.

**Localization support for capacities:**

* Added `fetch_localized_capacities` and `build_localized_capacities_rows` methods to `export.py` to retrieve and organize localized labels and descriptions from Metabase for each capacity QID, including truncation for long strings.
* Updated the export schema in `create_output_capacities` to set the `name` and `description` fields as type `localized` instead of `string`.
* Refactored the export process in `handle` to use the new localized data fetching and row building methods, replacing the previous SPARQL query and response processing logic.

**Testing updates:**

* Modified tests in `test_export.py` to expect and validate the new localized data structures, including schema type changes and localized value formats. [[1]](diffhunk://#diff-db6c3ff7e1e9ec7a624f61226344b51bcd56c0dc9dbbcf936a188c59c72d416fL161-R161) [[2]](diffhunk://#diff-db6c3ff7e1e9ec7a624f61226344b51bcd56c0dc9dbbcf936a188c59c72d416fL170-R171)
* Updated mocks and assertions in `test_handle` to use the new methods for fetching and building localized capacity data. [[1]](diffhunk://#diff-db6c3ff7e1e9ec7a624f61226344b51bcd56c0dc9dbbcf936a188c59c72d416fL350-R351) [[2]](diffhunk://#diff-db6c3ff7e1e9ec7a624f61226344b51bcd56c0dc9dbbcf936a188c59c72d416fL365-R366) [[3]](diffhunk://#diff-db6c3ff7e1e9ec7a624f61226344b51bcd56c0dc9dbbcf936a188c59c72d416fL384-R433)
* Added new tests for `build_localized_capacities_rows` and for truncation behavior in `fetch_localized_capacities`.