### PR TITLE
Translate capacities

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -30,6 +30,7 @@ INSTALLED_APPS = [
     'message',
     'projects',
     'portal',
+    'translate',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -169,7 +169,7 @@ REST_KNOX = {'TOKEN_TTL': timedelta(days=30)}
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Capacity Exchange (CapX) API',
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
-    'VERSION': '2.1.51',
+    'VERSION': '2.1.52',
     'SERVE_INCLUDE_SCHEMA': True,
     'SWAGGER_UI_DIST': 'SIDECAR',
     'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',

--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -169,7 +169,7 @@ REST_KNOX = {'TOKEN_TTL': timedelta(days=30)}
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Capacity Exchange (CapX) API',
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
-    'VERSION': '2.1.50',
+    'VERSION': '2.1.51',
     'SERVE_INCLUDE_SCHEMA': True,
     'SWAGGER_UI_DIST': 'SIDECAR',
     'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',

--- a/CapX/urls.py
+++ b/CapX/urls.py
@@ -65,6 +65,7 @@ router.register('user_badge', UserBadgeViewSet, basename='user_badge')
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('portal/', include('portal.urls', namespace='portal')),
+    path('translate/', include('translate.urls', namespace='translate')),
     path('api-auth/', include("rest_framework.urls", namespace="rest_framework")),
     path('', include('social_django.urls')),
     path('tags/<str:tag_type>/<int:tag_id>/', UsersByTagViewSet.as_view({'get': 'list'}), name='tags'),

--- a/CapX/urls.py
+++ b/CapX/urls.py
@@ -33,6 +33,7 @@ from events.views import EventViewSet
 from message.views import MessageViewSet
 from projects.views import ProjectViewSet, ProjectMemberViewSet, ProjectMemberAcceptanceViewSet
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from translate.views_api import CapacityTranslationViewSet
 
 
 router = DefaultRouter()
@@ -61,6 +62,7 @@ router.register('list', QuickListViewSet, basename='list')
 router.register('letsconnect', LetsConnectViewSet, basename='letsconnect')
 router.register('badges', BadgeViewSet, basename='badges')
 router.register('user_badge', UserBadgeViewSet, basename='user_badge')
+router.register('translating', CapacityTranslationViewSet, basename='translating')
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/translate/apps.py
+++ b/translate/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class TranslateConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "translate"
+    verbose_name = "Translate"

--- a/translate/serializers.py
+++ b/translate/serializers.py
@@ -1,0 +1,33 @@
+from rest_framework import serializers
+
+
+class CapacityItemSerializer(serializers.Serializer):
+    qid = serializers.CharField()
+    metabase_id = serializers.CharField(allow_null=True, required=False)
+    lang = serializers.CharField()
+    label = serializers.CharField(allow_null=True, required=False)
+    description = serializers.CharField(allow_null=True, required=False)
+    fallback_label = serializers.CharField(allow_null=True, required=False)
+    fallback_description = serializers.CharField(allow_null=True, required=False)
+
+
+class TranslationSubmitSerializer(serializers.Serializer):
+    qid = serializers.CharField()
+    lang = serializers.CharField()
+    label = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+    description = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+
+    def validate(self, attrs):
+        qid = attrs.get('qid', '').strip()
+        lang = attrs.get('lang', '').strip()
+        label = attrs.get('label')
+        description = attrs.get('description')
+        if not qid or not lang:
+            raise serializers.ValidationError('Missing qid or lang.')
+        if label is None and description is None:
+            raise serializers.ValidationError('Provide at least label or description.')
+        if lang == 'en':
+            raise serializers.ValidationError('English (en) is the base language and cannot be edited.')
+        attrs['qid'] = qid
+        attrs['lang'] = lang
+        return attrs

--- a/translate/services.py
+++ b/translate/services.py
@@ -1,0 +1,194 @@
+import json
+import os
+from datetime import datetime
+from typing import Dict, Optional
+
+import requests
+from django.conf import settings
+
+METABASE_API_ENDPOINT = "https://metabase.wikibase.cloud/w/api.php"
+METABASE_SPARQL_ENDPOINT = "https://metabase.wikibase.cloud/query/sparql"
+USER_AGENT = "CapX/Translate/1.0"
+
+
+class MetabaseClient:
+    """Minimal client for Wikibase (Metabase) to fetch and edit terms."""
+
+    def __init__(self):
+        self._session: Optional[requests.Session] = None
+        self._token: Optional[str] = None
+        self.metabase_ids: Dict[str, str] = {}
+
+    # --- Auth
+    def login_bot(self):
+        """Login as CapacityExchangeBot using credentials from settings_local."""
+        username = os.environ.get("METABASE_USERNAME")
+        password = os.environ.get("METABASE_PASSWORD")
+        if not username or not password:
+            raise RuntimeError("Missing CAPX_BOT_USERNAME/CAPX_BOT_PASSWORD in settings_local.py or env")
+        self._session, self._token = self._mw_login(METABASE_API_ENDPOINT, username, password)
+        return self
+
+    def _mw_login(self, api_endpoint, username, password):
+        s = requests.Session()
+        s.headers.update({"User-Agent": USER_AGENT})
+        r = s.get(api_endpoint, params={
+            "action": "query",
+            "meta": "tokens",
+            "type": "login",
+            "format": "json",
+        }, timeout=30)
+        r.raise_for_status()
+        login_token = r.json().get("query", {}).get("tokens", {}).get("logintoken")
+        if not login_token:
+            raise RuntimeError("Failed to get login token.")
+
+        r = s.post(api_endpoint, data={
+            "action": "login",
+            "lgname": username,
+            "lgpassword": password,
+            "lgtoken": login_token,
+            "format": "json",
+        }, timeout=30)
+        r.raise_for_status()
+        if r.json().get("login", {}).get("result") != "Success":
+            raise RuntimeError("Login failed for Metabase")
+
+        r = s.get(api_endpoint, params={
+            "action": "query",
+            "meta": "tokens",
+            "format": "json",
+        }, timeout=30)
+        r.raise_for_status()
+        csrf = r.json().get("query", {}).get("tokens", {}).get("csrftoken")
+        if not csrf:
+            raise RuntimeError("Failed to obtain CSRF token.")
+        return s, csrf
+
+    # --- Fetch
+    def fetch_map_and_terms(self, qids):
+        """
+        Returns a mapping: {
+          qid: { lang: { 'label': str|None, 'description': str|None, 'metabase_id': 'Q123' } }
+        }
+        Also populates self.metabase_ids for quick lookup.
+        """
+        item_ids = " ".join(f"'{v}'" for v in qids if v)
+        if not item_ids:
+            return {}
+        headers = {"Accept": "application/sparql-results+json", "User-Agent": USER_AGENT}
+        # First, map value (Wikidata QID) -> Metabase Item id
+        map_query = f"""PREFIX wbt:<https://metabase.wikibase.cloud/prop/direct/>
+            PREFIX wb: <https://metabase.wikibase.cloud/entity/>
+            SELECT DISTINCT ?item ?value WHERE {{
+                VALUES ?value {{ {item_ids} }}
+                ?item wbt:P5 wb:Q34531.
+                ?item wbt:P67/wbt:P1 ?value.
+            }}"""
+        r = requests.get(METABASE_SPARQL_ENDPOINT, params={"query": map_query}, headers=headers, timeout=60)
+        r.raise_for_status()
+        map_data = r.json()
+        value_to_item = {}
+        for b in map_data.get("results", {}).get("bindings", []):
+            item_uri = b.get("item", {}).get("value")
+            value = b.get("value", {}).get("value")
+            item_id = self._parse_entity_id(item_uri) if item_uri else None
+            if item_id and value:
+                value_to_item[value] = item_id
+        self.metabase_ids = value_to_item
+
+        # Then fetch terms
+        query = f"""PREFIX wbt:<https://metabase.wikibase.cloud/prop/direct/>
+            PREFIX wb: <https://metabase.wikibase.cloud/entity/>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+            PREFIX schema: <http://schema.org/>
+            SELECT ?item ?value ?language (SAMPLE(?label) AS ?label) (SAMPLE(?description) AS ?description) WHERE {{  
+                VALUES ?value {{ {item_ids} }}
+                ?item wbt:P5 wb:Q34531.
+                ?item wbt:P67/wbt:P1 ?value.  
+                {{
+                    ?item rdfs:label ?label.
+                    BIND(LANG(?label) AS ?language)
+                }}
+                UNION
+                {{
+                    ?item schema:description ?description.
+                    BIND(LANG(?description) AS ?language)
+                }}
+            }}
+            GROUP BY ?item ?value ?language
+            ORDER BY ?language
+            """
+        r = requests.get(METABASE_SPARQL_ENDPOINT, params={"query": query}, headers=headers, timeout=60)
+        r.raise_for_status()
+        data = r.json()
+        terms_by_value: Dict[str, Dict[str, Dict[str, str]]] = {}
+        for b in data.get("results", {}).get("bindings", []):
+            item_uri = b.get("item", {}).get("value")
+            item_id = self._parse_entity_id(item_uri) if item_uri else None
+            label = b.get("label", {}).get("value")
+            description = b.get("description", {}).get("value")
+            lang = b.get("language", {}).get("value")
+            value = b.get("value", {}).get("value")
+            if not item_id or not lang or not value:
+                continue
+            terms_by_value.setdefault(value, {})[lang] = {
+                "label": label,
+                "description": description,
+                "metabase_id": item_id,
+            }
+        return terms_by_value
+
+    # --- Edits
+    def set_term(self, metabase_id: str, lang: str, field: str, value: str, editor_username: str):
+        if field not in ("label", "description"):
+            raise ValueError("field must be 'label' or 'description'")
+        if not self._session or not self._token:
+            raise RuntimeError("MetabaseClient not logged in")
+        action = "wbsetlabel" if field == "label" else "wbsetdescription"
+        data = {
+            "action": action,
+            "id": metabase_id,
+            "language": lang,
+            "value": value,
+            "token": self._token,
+            "summary": f"CapX translate: set {field} ({lang}) by {editor_username}",
+            "format": "json",
+            "assert": "user",
+            "maxlag": "5",
+        }
+        r = self._session.post(METABASE_API_ENDPOINT, data=data, timeout=60)
+        r.raise_for_status()
+        j = r.json()
+        if "error" in j or j.get("success") is False:
+            raise RuntimeError(f"Metabase API error for {metabase_id}/{lang} {field}: {j}")
+
+    # --- Helpers
+    def _parse_entity_id(self, uri: str) -> Optional[str]:
+        try:
+            path = uri.split("/entity/")[-1]
+            return path if path.startswith("Q") else None
+        except Exception:
+            return None
+
+
+def build_capacity_list(terms_by_qid: Dict[str, Dict[str, Dict[str, str]]], lang: str, fallback: str = 'en'):
+    """
+    Build a flattened list suitable for UI/API consumption.
+    Each item: { qid, metabase_id, lang, label, description, fallback_label, fallback_description }
+    """
+    items = []
+    for qid, lang_map in terms_by_qid.items():
+        current = lang_map.get(lang, {})
+        fb = lang_map.get(fallback, {})
+        metabase_id = (current or fb or {}).get('metabase_id')
+        items.append({
+            'qid': qid,
+            'metabase_id': metabase_id,
+            'lang': lang,
+            'label': (current or {}).get('label'),
+            'description': (current or {}).get('description'),
+            'fallback_label': (fb or {}).get('label'),
+            'fallback_description': (fb or {}).get('description'),
+        })
+    return items

--- a/translate/templates/translate/index.html
+++ b/translate/templates/translate/index.html
@@ -216,7 +216,7 @@
       const fallback = document.getElementById('fallback').value.trim();
       loadingEl.classList.add('active');
       try {
-        const resp = await fetch(`/translate/api/capacities/?lang=${encodeURIComponent(lang)}&fallback=${encodeURIComponent(fallback)}`);
+        const resp = await fetch(`/translating/?lang=${encodeURIComponent(lang)}&fallback=${encodeURIComponent(fallback)}`);
         const data = await resp.json();
         currentItems = data.results || [];
         changedQIDs.clear();
@@ -293,7 +293,7 @@
       btn.disabled = true;
       btn.textContent = 'Saving…';
       try {
-        const resp = await fetch('/translate/api/submit/', {
+        const resp = await fetch('/translating/', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/translate/templates/translate/index.html
+++ b/translate/templates/translate/index.html
@@ -81,7 +81,7 @@
         <span id="stats"></span>
       </div>
     </div>
-    <p class="license-note">By submitting translations you agree to release them under the <strong>CC0 1.0 Universal Public Domain Dedication</strong>, consistent with Wikidata. Do not submit text you cannot freely dedicate to the public domain.</p>
+    <p class="license-note">By submitting translations you agree to release them under the <strong>CC0 1.0 Universal Public Domain Dedication</strong>, consistent with Metabase/Wikidata. Do not submit translations you cannot freely dedicate to the public domain.</p>
 
     <div class="filter-bar">
       <label><input type="checkbox" id="filter-missing" > Show only missing</label>

--- a/translate/templates/translate/index.html
+++ b/translate/templates/translate/index.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Translate – Capacities</title>
+  <link rel="stylesheet" href="/static/styles.css">
+  <style>
+    body { font-family: system-ui, Arial, sans-serif; margin: 0; background:#f6f7f8; }
+    header { background:#2d4b69; color:#fff; padding:1rem 1.5rem; }
+    h1 { margin:0; font-size:1.4rem; }
+    main { padding:1.25rem; }
+    .controls { display:flex; flex-wrap:wrap; gap:1rem; align-items:flex-end; margin-bottom:1rem; }
+    .controls label { font-size:.85rem; font-weight:600; text-transform:uppercase; color:#444; }
+    .controls input, .controls select { padding:.4rem .55rem; border:1px solid #bbb; border-radius:4px; }
+    button { cursor:pointer; background:#1d70b8; color:#fff; border:none; padding:.5rem .9rem; border-radius:4px; font-size:.85rem; }
+    button[disabled] { opacity:.6; cursor:wait; }
+    table { width:100%; border-collapse: collapse; background:#fff; box-shadow:0 1px 2px rgba(0,0,0,.08); }
+    th { background:#fafafa; position:sticky; top:0; z-index:2; }
+    th, td { border:1px solid #e0e0e0; padding:6px; vertical-align:top; }
+    tbody tr.missing { background:#fff8e1; }
+    tbody tr.ok { background:#f5fff7; }
+    td textarea, td input { width:100%; font-size:.85rem; }
+    td textarea { resize:vertical; min-height:60px; }
+    .fallback { font-size:.75rem; color:#555; }
+    .fallback strong { display:block; color:#222; }
+    .status { font-size:.7rem; font-weight:600; text-transform:uppercase; letter-spacing:.5px; }
+    .status.missing { color:#b34d00; }
+    .status.ok { color:#317031; }
+    .status.pending { color:#946200; }
+    .filter-bar { margin:.5rem 0 1rem; font-size:.75rem; display:flex; gap:1rem; align-items:center; }
+    .pill { display:inline-block; padding:.15rem .4rem; border-radius:12px; background:#eee; font-size:.65rem; margin-left:.4rem; }
+    .row-actions { display:flex; flex-direction:column; gap:.35rem; }
+    .save-all { background:#007a33; }
+    .loading-indicator { display:none; margin-left:.75rem; }
+    .loading-indicator.active { display:inline-flex; align-items:center; }
+    .spinner { width:16px; height:16px; border:3px solid #c4d3e2; border-top-color:#1d70b8; border-radius:50%; animation:spin .8s linear infinite; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .changed-marker { border:2px solid #ff9800 !important; }
+    .search-box { flex:1; }
+    .license-note { font-size:.7rem; color:#444; background:#fff; padding:.5rem .75rem; border-left:4px solid #1d70b8; margin:.75rem 0 0; line-height:1.3; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Capacities Translation Workspace</h1>
+  </header>
+  <main>
+    <p style="margin-top:0; font-size:.85rem; line-height:1.4">Translate capacity labels and descriptions across languages. Missing entries are highlighted. Changes are saved using the CapacityExchange bot. Fallback shows English for context.</p>
+
+    <div class="controls">
+      <div>
+        <label for="lang">Language code</label><br>
+        <input id="lang" value="pt-br" list="lang-suggestions" />
+        <datalist id="lang-suggestions">
+          <option>pt-br</option>
+          <option>fr</option>
+          <option>es</option>
+          <option>de</option>
+        </datalist>
+      </div>
+      <div>
+        <label for="fallback">Fallback</label><br>
+        <select id="fallback">
+          <option value="en" selected>English (en)</option>
+          <option value="pt-br">Portuguese (pt-br)</option>
+          <option value="es">Spanish (es)</option>
+        </select>
+      </div>
+      <div class="search-box">
+        <label for="search">Search</label><br>
+        <input id="search" placeholder="Filter by QID or fallback label..." />
+      </div>
+      <div>
+        <button id="load">Load</button>
+        <span id="loading" class="loading-indicator"><span class="spinner" aria-label="Loading"></span></span>
+      </div>
+      <div>
+        <button id="save-all" class="save-all" disabled>Save All Changed</button>
+      </div>
+      <div style="margin-left:auto; font-size:.7rem; text-align:right;">
+        <span id="stats"></span>
+      </div>
+    </div>
+    <p class="license-note">By submitting translations you agree to release them under the <strong>CC0 1.0 Universal Public Domain Dedication</strong>, consistent with Wikidata. Do not submit text you cannot freely dedicate to the public domain.</p>
+
+    <div class="filter-bar">
+      <label><input type="checkbox" id="filter-missing" > Show only missing</label>
+      <label><input type="checkbox" id="filter-changed" > Show only changed</label>
+    </div>
+
+    <table id="tbl" style="display:none;">
+      <thead>
+        <tr>
+          <th style="width:80px;">QID</th>
+          <th style="width:18%;">Label <span class="pill" title="Current language">L</span></th>
+          <th style="width:30%;">Description <span class="pill">D</span></th>
+          <th style="width:22%;">Fallback</th>
+          <th style="width:140px;">Actions</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </main>
+  <script>
+    // --- CSRF helper (Django session auth)
+    function getCookie(name) {
+      const value = `; ${document.cookie}`;
+      const parts = value.split(`; ${name}=`);
+      if (parts.length === 2) return parts.pop().split(';').shift();
+    }
+    const csrftoken = getCookie('csrftoken');
+
+    const loadBtn = document.getElementById('load');
+    const tbl = document.getElementById('tbl');
+    const tbody = tbl.querySelector('tbody');
+    const statsEl = document.getElementById('stats');
+    const filterMissingEl = document.getElementById('filter-missing');
+    const filterChangedEl = document.getElementById('filter-changed');
+    const saveAllBtn = document.getElementById('save-all');
+    const searchEl = document.getElementById('search');
+    const loadingEl = document.getElementById('loading');
+
+    let currentItems = [];
+    let changedQIDs = new Set();
+    let pendingQIDs = new Map(); // qid -> timestamp saved
+    const PENDING_REFRESH_MS = 90000; // 1.5 minutes default propagation window
+
+    function updateStatsOnly() {
+      const statsEl = document.getElementById('stats');
+      statsEl.textContent = `${document.querySelectorAll('#tbl tbody tr').length} displayed / ${currentItems.length} total | Changed: ${changedQIDs.size}`;
+      saveAllBtn.disabled = changedQIDs.size === 0;
+    }
+
+    function markRowChanged(qid) {
+      changedQIDs.add(qid);
+      const row = tbody.querySelector(`tr[data-qid="${qid}"]`);
+      if (!row) return;
+      const labelEl = row.querySelector('input[data-field="label"]');
+      const descEl = row.querySelector('textarea[data-field="description"]');
+      if (labelEl) labelEl.classList.add('changed-marker');
+      if (descEl) descEl.classList.add('changed-marker');
+      const missing = !(labelEl && labelEl.value.trim()) || !(descEl && descEl.value.trim());
+      // Update status text without rebuilding the row
+      const statusSpan = row.querySelector('.status');
+      if (statusSpan) {
+        // If already pending keep pending label
+        if (pendingQIDs.has(qid)) {
+          statusSpan.textContent = 'Pending';
+          statusSpan.className = 'status pending';
+        } else {
+          statusSpan.textContent = missing ? 'Missing' : 'Complete';
+          statusSpan.className = `status ${missing ? 'missing' : 'ok'}`;
+        }
+      }
+      // Enable reset button
+      const resetBtn = row.querySelector('button[data-action="reset"]');
+      if (resetBtn) resetBtn.disabled = false;
+      updateStatsOnly();
+    }
+
+    function renderRows() {
+      const lang = document.getElementById('lang').value.trim();
+      const showMissingOnly = filterMissingEl.checked;
+      const showChangedOnly = filterChangedEl.checked;
+      const searchTerm = searchEl.value.trim().toLowerCase();
+      tbody.innerHTML = '';
+      let visible = 0;
+      for (const it of currentItems) {
+        const missing = (!it.label || !it.description);
+        const changed = changedQIDs.has(it.qid);
+        const pending = pendingQIDs.has(it.qid);
+        if (showMissingOnly && !missing) continue;
+        if (showChangedOnly && !changed) continue;
+        if (searchTerm) {
+          const fallbackCombo = `${it.fallback_label || ''} ${it.qid}`.toLowerCase();
+          if (!fallbackCombo.includes(searchTerm)) continue;
+        }
+        const tr = document.createElement('tr');
+        tr.className = missing ? 'missing' : 'ok';
+        tr.dataset.qid = it.qid;
+        const statusClass = pending ? 'pending' : (missing ? 'missing' : 'ok');
+        const statusText = pending ? 'Pending' : (missing ? 'Missing' : 'Complete');
+        tr.innerHTML = `
+          <td><strong>${it.qid}</strong><br><span class="status ${statusClass}">${statusText}</span></td>
+          <td><input data-field="label" data-qid="${it.qid}" value="${it.label || ''}" placeholder="Label (${lang})"/></td>
+          <td><textarea data-field="description" data-qid="${it.qid}" placeholder="Description (${lang})">${it.description || ''}</textarea></td>
+          <td class="fallback"><strong>${it.fallback_label || ''}</strong>${it.fallback_description ? '<br>'+escapeHtml(it.fallback_description) : ''}</td>
+          <td class="row-actions">
+            <button data-action="save" data-qid="${it.qid}" class="save-one">Save</button>
+            <button data-action="reset" data-qid="${it.qid}" ${changed ? '' : 'disabled'}>Reset</button>
+          </td>
+        `;
+        tbody.appendChild(tr);
+        visible++;
+        // Mark changed styling
+        if (changed) {
+          tr.querySelector('input[data-field="label"]').classList.add('changed-marker');
+          tr.querySelector('textarea[data-field="description"]').classList.add('changed-marker');
+        }
+      }
+      tbl.style.display = visible ? 'table' : 'none';
+      statsEl.textContent = `${visible} displayed / ${currentItems.length} total | Changed: ${changedQIDs.size}`;
+      saveAllBtn.disabled = changedQIDs.size === 0;
+    }
+
+    function escapeHtml(s) {
+      return (s || '').replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+    }
+
+    async function load() {
+      const lang = document.getElementById('lang').value.trim();
+      if (lang === 'en') {
+        alert('English (en) is the base language and cannot be edited. Please choose another language.');
+        return;
+      }
+      const fallback = document.getElementById('fallback').value.trim();
+      loadingEl.classList.add('active');
+      try {
+        const resp = await fetch(`/translate/api/capacities/?lang=${encodeURIComponent(lang)}&fallback=${encodeURIComponent(fallback)}`);
+        const data = await resp.json();
+        currentItems = data.results || [];
+        changedQIDs.clear();
+        renderRows();
+      } catch (e) {
+        alert('Failed to load: ' + e);
+      } finally {
+        loadingEl.classList.remove('active');
+      }
+    }
+
+    // Incremental change tracking to avoid full re-render (which caused scroll/focus jump)
+    tbody.addEventListener('input', (ev) => {
+      const fieldEl = ev.target.closest('[data-field]');
+      if (!fieldEl) return;
+      markRowChanged(fieldEl.dataset.qid);
+    });
+
+    tbody.addEventListener('click', async (ev) => {
+      const btn = ev.target.closest('button[data-action]');
+      if (!btn) return;
+      const action = btn.dataset.action;
+      const qid = btn.dataset.qid;
+      if (action === 'reset') {
+        // Reset to original loaded values
+        const original = currentItems.find(it => it.qid === qid);
+        if (!original) return;
+        const labelEl = tbody.querySelector(`input[data-field="label"][data-qid="${qid}"]`);
+        const descEl = tbody.querySelector(`textarea[data-field="description"][data-qid="${qid}"]`);
+        if (labelEl) labelEl.value = original.label || '';
+        if (descEl) descEl.value = original.description || '';
+        changedQIDs.delete(qid);
+        // Remove change markers
+        if (labelEl) labelEl.classList.remove('changed-marker');
+        if (descEl) descEl.classList.remove('changed-marker');
+        // Recompute missing status for this row only
+        const missingNow = !original.label || !original.description;
+        const row = tbody.querySelector(`tr[data-qid="${qid}"]`);
+        if (row) {
+          const pending = pendingQIDs.has(qid);
+          row.className = pending ? 'pending' : (missingNow ? 'missing' : 'ok');
+          const statusSpan = row.querySelector('.status');
+          if (statusSpan) {
+            if (pending) {
+              statusSpan.textContent = 'Pending';
+              statusSpan.className = 'status pending';
+            } else {
+              statusSpan.textContent = missingNow ? 'Missing' : 'Complete';
+              statusSpan.className = `status ${missingNow ? 'missing' : 'ok'}`;
+            }
+          }
+          const resetBtn = row.querySelector('button[data-action="reset"]');
+          if (resetBtn) resetBtn.disabled = true;
+        }
+        updateStatsOnly();
+        return;
+      }
+      if (action === 'save') {
+        await saveSingle(qid, btn);
+      }
+    });
+
+    async function saveSingle(qid, btn) {
+      const lang = document.getElementById('lang').value.trim();
+      if (lang === 'en') {
+        alert('English (en) is not editable.');
+        return;
+      }
+      const labelEl = tbody.querySelector(`input[data-field="label"][data-qid="${qid}"]`);
+      const descEl  = tbody.querySelector(`textarea[data-field="description"][data-qid="${qid}"]`);
+      const payload = { qid, lang };
+      payload.label = labelEl ? labelEl.value : undefined;
+      payload.description = descEl ? descEl.value : undefined;
+      btn.disabled = true;
+      btn.textContent = 'Saving…';
+      try {
+        const resp = await fetch('/translate/api/submit/', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': csrftoken || ''
+          },
+            body: JSON.stringify(payload)
+        });
+        if (!resp.ok) throw new Error(await resp.text());
+        changedQIDs.delete(qid);
+        // Optimistically mark as pending without full reload
+        pendingQIDs.set(qid, Date.now());
+        // Update currentItems local copy for qid
+        const item = currentItems.find(i => i.qid === qid);
+        if (item) {
+          if (payload.label !== undefined) item.label = payload.label;
+          if (payload.description !== undefined) item.description = payload.description;
+        }
+        markRowPending(qid);
+        schedulePendingAutoRefresh();
+      } catch (e) {
+        alert('Failed to submit: ' + e);
+      } finally {
+        btn.disabled = false;
+        btn.textContent = 'Save';
+      }
+    }
+
+    function markRowPending(qid) {
+      const row = tbody.querySelector(`tr[data-qid="${qid}"]`);
+      if (!row) return;
+      const statusSpan = row.querySelector('.status');
+      if (statusSpan) {
+        statusSpan.textContent = 'Pending';
+        statusSpan.className = 'status pending';
+      }
+      updateStatsOnly();
+    }
+
+    function schedulePendingAutoRefresh() {
+      // If already scheduled, skip (simple approach: one timeout)
+      if (schedulePendingAutoRefresh._scheduled) return;
+      schedulePendingAutoRefresh._scheduled = true;
+      setTimeout(() => {
+        schedulePendingAutoRefresh._scheduled = false;
+        // Remove any pending older than threshold and trigger a reload to fetch updated values
+        if (pendingQIDs.size) {
+          load(); // this will clear pending map after reload
+          pendingQIDs.clear();
+          updateStatsOnly();
+        }
+      }, PENDING_REFRESH_MS);
+    }
+
+
+    saveAllBtn.addEventListener('click', async () => {
+      if (changedQIDs.size === 0) return;
+      saveAllBtn.disabled = true;
+      saveAllBtn.textContent = 'Saving…';
+      try {
+        // Sequential to avoid rate limits
+        for (const qid of Array.from(changedQIDs)) {
+          const rowBtn = tbody.querySelector(`button[data-action="save"][data-qid="${qid}"]`);
+          await saveSingle(qid, rowBtn || { disabled:false, textContent:'Save' });
+        }
+      } finally {
+        saveAllBtn.textContent = 'Save All Changed';
+        saveAllBtn.disabled = changedQIDs.size === 0;
+      }
+    });
+
+    filterMissingEl.addEventListener('change', renderRows);
+    filterChangedEl.addEventListener('change', renderRows);
+    searchEl.addEventListener('input', renderRows);
+    loadBtn.addEventListener('click', load);
+    // Initial load
+    load();
+  </script>
+</body>
+</html>

--- a/translate/templates/translate/index.html
+++ b/translate/templates/translate/index.html
@@ -123,7 +123,7 @@
     let currentItems = [];
     let changedQIDs = new Set();
     let pendingQIDs = new Map(); // qid -> timestamp saved
-    const PENDING_REFRESH_MS = 90000; // 1.5 minutes default propagation window
+    const PENDING_REFRESH_MS = 30000; // 30 seconds default propagation window
 
     function updateStatsOnly() {
       const statsEl = document.getElementById('stats');
@@ -132,6 +132,8 @@
     }
 
     function markRowChanged(qid) {
+      // Do not allow modifications while pending propagation
+      if (pendingQIDs.has(qid)) return;
       changedQIDs.add(qid);
       const row = tbody.querySelector(`tr[data-qid="${qid}"]`);
       if (!row) return;
@@ -140,19 +142,11 @@
       if (labelEl) labelEl.classList.add('changed-marker');
       if (descEl) descEl.classList.add('changed-marker');
       const missing = !(labelEl && labelEl.value.trim()) || !(descEl && descEl.value.trim());
-      // Update status text without rebuilding the row
       const statusSpan = row.querySelector('.status');
       if (statusSpan) {
-        // If already pending keep pending label
-        if (pendingQIDs.has(qid)) {
-          statusSpan.textContent = 'Pending';
-          statusSpan.className = 'status pending';
-        } else {
-          statusSpan.textContent = missing ? 'Missing' : 'Complete';
-          statusSpan.className = `status ${missing ? 'missing' : 'ok'}`;
-        }
+        statusSpan.textContent = missing ? 'Missing' : 'Complete';
+        statusSpan.className = `status ${missing ? 'missing' : 'ok'}`;
       }
-      // Enable reset button
       const resetBtn = row.querySelector('button[data-action="reset"]');
       if (resetBtn) resetBtn.disabled = false;
       updateStatsOnly();
@@ -180,14 +174,15 @@
         tr.dataset.qid = it.qid;
         const statusClass = pending ? 'pending' : (missing ? 'missing' : 'ok');
         const statusText = pending ? 'Pending' : (missing ? 'Missing' : 'Complete');
+        const disabledAttr = pending ? 'disabled' : '';
         tr.innerHTML = `
           <td><strong>${it.qid}</strong><br><span class="status ${statusClass}">${statusText}</span></td>
-          <td><input data-field="label" data-qid="${it.qid}" value="${it.label || ''}" placeholder="Label (${lang})"/></td>
-          <td><textarea data-field="description" data-qid="${it.qid}" placeholder="Description (${lang})">${it.description || ''}</textarea></td>
+          <td><input ${disabledAttr} data-field="label" data-qid="${it.qid}" value="${it.label || ''}" placeholder="Label (${lang})"/></td>
+          <td><textarea ${disabledAttr} data-field="description" data-qid="${it.qid}" placeholder="Description (${lang})">${it.description || ''}</textarea></td>
           <td class="fallback"><strong>${it.fallback_label || ''}</strong>${it.fallback_description ? '<br>'+escapeHtml(it.fallback_description) : ''}</td>
           <td class="row-actions">
-            <button data-action="save" data-qid="${it.qid}" class="save-one">Save</button>
-            <button data-action="reset" data-qid="${it.qid}" ${changed ? '' : 'disabled'}>Reset</button>
+            <button ${disabledAttr} data-action="save" data-qid="${it.qid}" class="save-one">Save</button>
+            <button ${disabledAttr} data-action="reset" data-qid="${it.qid}" ${changed ? '' : 'disabled'}>Reset</button>
           </td>
         `;
         tbody.appendChild(tr);
@@ -287,11 +282,17 @@
       }
       const labelEl = tbody.querySelector(`input[data-field="label"][data-qid="${qid}"]`);
       const descEl  = tbody.querySelector(`textarea[data-field="description"][data-qid="${qid}"]`);
+      const row = tbody.querySelector(`tr[data-qid="${qid}"]`);
+      const resetBtn = row ? row.querySelector('button[data-action="reset"]') : null;
       const payload = { qid, lang };
       payload.label = labelEl ? labelEl.value : undefined;
       payload.description = descEl ? descEl.value : undefined;
       btn.disabled = true;
       btn.textContent = 'Saving…';
+      // Immediately block editing while request is in flight
+      if (labelEl) labelEl.disabled = true;
+      if (descEl) descEl.disabled = true;
+      if (resetBtn) resetBtn.disabled = true;
       try {
         const resp = await fetch('/translating/', {
           method: 'POST',
@@ -315,9 +316,19 @@
         schedulePendingAutoRefresh();
       } catch (e) {
         alert('Failed to submit: ' + e);
-      } finally {
+        // Re-enable editing controls since save failed
+        if (labelEl) labelEl.disabled = false;
+        if (descEl) descEl.disabled = false;
+        if (resetBtn) resetBtn.disabled = !changedQIDs.has(qid); // restore previous state
         btn.disabled = false;
-        btn.textContent = 'Save';
+      } finally {
+        // If pending state applied, keep disabled; else restore button
+        if (pendingQIDs.has(qid)) {
+          btn.disabled = true;
+          btn.textContent = 'Save';
+        } else if (!btn.disabled) {
+          btn.textContent = 'Save';
+        }
       }
     }
 
@@ -329,6 +340,15 @@
         statusSpan.textContent = 'Pending';
         statusSpan.className = 'status pending';
       }
+      // Disable editing controls while pending
+      const labelEl = row.querySelector('input[data-field="label"]');
+      const descEl = row.querySelector('textarea[data-field="description"]');
+      const saveBtn = row.querySelector('button[data-action="save"]');
+      const resetBtn = row.querySelector('button[data-action="reset"]');
+      if (labelEl) labelEl.disabled = true;
+      if (descEl) descEl.disabled = true;
+      if (saveBtn) saveBtn.disabled = true;
+      if (resetBtn) resetBtn.disabled = true;
       updateStatsOnly();
     }
 
@@ -353,6 +373,19 @@
       saveAllBtn.disabled = true;
       saveAllBtn.textContent = 'Saving…';
       try {
+        // Pre-lock all changed rows immediately for clearer UX
+        for (const qid of Array.from(changedQIDs)) {
+          const row = tbody.querySelector(`tr[data-qid="${qid}"]`);
+          if (!row) continue;
+          const labelEl = row.querySelector('input[data-field="label"]');
+          const descEl = row.querySelector('textarea[data-field="description"]');
+          const saveBtn = row.querySelector('button[data-action="save"]');
+          const resetBtn = row.querySelector('button[data-action="reset"]');
+          if (labelEl) labelEl.disabled = true;
+          if (descEl) descEl.disabled = true;
+          if (saveBtn) saveBtn.disabled = true; // will be re-enabled in saveSingle catch if failure
+          if (resetBtn) resetBtn.disabled = true;
+        }
         // Sequential to avoid rate limits
         for (const qid of Array.from(changedQIDs)) {
           const rowBtn = tbody.querySelector(`button[data-action="save"][data-qid="${qid}"]`);

--- a/translate/templates/translate/login.html
+++ b/translate/templates/translate/login.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Translate – Login</title>
+  <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+  <main>
+    <h1>Translate</h1>
+    <p>Sign in via MediaWiki to start translating capacities.</p>
+    <p><a href="{{ social_login_url }}">Login with MediaWiki</a></p>
+  </main>
+</body>
+</html>

--- a/translate/urls.py
+++ b/translate/urls.py
@@ -1,5 +1,6 @@
-from django.urls import path
-from . import views, views_api
+from django.urls import path, include
+from rest_framework.routers import SimpleRouter
+from . import views
 
 app_name = 'translate'
 
@@ -9,8 +10,4 @@ urlpatterns = [
     path('logout/', views.logout_view, name='logout'),
     path('oauth/begin/', views.oauth_begin, name='oauth_begin'),
     path('oauth/', views.oauth_callback, name='oauth_callback'),
-
-    # API endpoints under the same namespace to avoid modifying the global router
-    path('api/capacities/', views_api.capacities_list, name='api_capacities_list'),
-    path('api/submit/', views_api.submit_translation, name='api_submit_translation'),
 ]

--- a/translate/urls.py
+++ b/translate/urls.py
@@ -1,0 +1,16 @@
+from django.urls import path
+from . import views, views_api
+
+app_name = 'translate'
+
+urlpatterns = [
+    path('', views.index, name='index'),
+    path('login/', views.login_view, name='login'),
+    path('logout/', views.logout_view, name='logout'),
+    path('oauth/begin/', views.oauth_begin, name='oauth_begin'),
+    path('oauth/', views.oauth_callback, name='oauth_callback'),
+
+    # API endpoints under the same namespace to avoid modifying the global router
+    path('api/capacities/', views_api.capacities_list, name='api_capacities_list'),
+    path('api/submit/', views_api.submit_translation, name='api_submit_translation'),
+]

--- a/translate/views.py
+++ b/translate/views.py
@@ -1,0 +1,64 @@
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth.decorators import login_required as django_login_required
+from django.shortcuts import render, redirect
+from django.contrib.auth import logout
+from django.contrib import messages
+from django.urls import reverse
+from django.views.decorators.http import require_GET
+from social_django.utils import load_strategy, load_backend
+
+INDEX_URL_NAME = 'translate:index'
+
+# A login-required decorator that ignores settings.LOGIN_URL and always
+# redirects to the translate login page.
+
+def translate_login_required(view_func=None, *, redirect_field_name: str = REDIRECT_FIELD_NAME):
+    decorator = django_login_required(
+        redirect_field_name=redirect_field_name,
+        login_url='/translate/login/'
+    )
+    return decorator(view_func) if view_func else decorator
+
+
+@require_GET
+@translate_login_required
+def index(request):
+    # Minimal shell page; the API provides data. We'll resembled MW Translate later.
+    return render(request, 'translate/index.html', {
+        'user': request.user,
+    })
+
+
+@require_GET
+def login_view(request):
+    if request.user.is_authenticated:
+        return redirect(INDEX_URL_NAME)
+    oauth_begin_url = reverse('translate:oauth_begin')
+    return render(request, 'translate/login.html', {'social_login_url': oauth_begin_url})
+
+
+@require_GET
+def logout_view(request):
+    logout(request)
+    messages.success(request, 'You have been logged out.')
+    return redirect('translate:login')
+
+
+@require_GET
+def oauth_begin(request):
+    """Start MediaWiki OAuth using social_django for translate area."""
+    strategy = load_strategy(request)
+    translate_return_path = reverse(INDEX_URL_NAME)
+    strategy.session_set('next', translate_return_path)
+    backend = load_backend(strategy, 'mediawiki', redirect_uri=None)
+    response = backend.start()
+    return response
+
+
+@require_GET
+def oauth_callback(request):
+    complete_url = reverse('social:complete', kwargs={'backend': 'mediawiki'})
+    qs = request.META.get('QUERY_STRING')
+    if qs:
+        complete_url = f"{complete_url}?{qs}"
+    return redirect(complete_url)

--- a/translate/views.py
+++ b/translate/views.py
@@ -23,7 +23,6 @@ def translate_login_required(view_func=None, *, redirect_field_name: str = REDIR
 @require_GET
 @translate_login_required
 def index(request):
-    # Minimal shell page; the API provides data. We'll resembled MW Translate later.
     return render(request, 'translate/index.html', {
         'user': request.user,
     })

--- a/translate/views_api.py
+++ b/translate/views_api.py
@@ -1,0 +1,75 @@
+from typing import List
+
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework import status
+
+from skills.models import Skill
+from .services import MetabaseClient, build_capacity_list
+
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def capacities_list(request):
+    """Return list of capacities with current and fallback terms for a given lang.
+    Query params:
+      - lang: required language code (e.g., 'pt-br')
+      - fallback: optional fallback language (default 'en')
+    """
+    lang = request.query_params.get('lang')
+    if not lang:
+        return Response({'detail': 'Missing lang parameter'}, status=status.HTTP_400_BAD_REQUEST)
+    fallback = request.query_params.get('fallback', 'en')
+
+    qids: List[str] = list(
+        Skill.objects.order_by('pk').values_list('skill_wikidata_item', flat=True)
+    )
+    client = MetabaseClient()
+    terms = client.fetch_map_and_terms(qids)
+    items = build_capacity_list(terms, lang=lang, fallback=fallback)
+    # Sort by missing first to help translators
+    def is_missing(it):
+        return (not it.get('label')) or (not it.get('description'))
+    items.sort(key=lambda it: (not is_missing(it), (it.get('fallback_label') or '') .lower()))
+    return Response({'results': items})
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def submit_translation(request):
+    """Submit label/description for a given qid/lang using the bot.
+    Body (JSON): { qid: 'Q...', lang: 'xx', label?: str, description?: str }
+    """
+    payload = request.data or {}
+    qid = (payload.get('qid') or '').strip()
+    lang = (payload.get('lang') or '').strip()
+    label = payload.get('label')
+    description = payload.get('description')
+
+    if not qid or not lang or (label is None and description is None):
+        return Response({'detail': 'Missing qid, lang, or fields'}, status=status.HTTP_400_BAD_REQUEST)
+    if lang == 'en':
+        return Response({'detail': 'English (en) is the base language and cannot be edited.'}, status=status.HTTP_400_BAD_REQUEST)
+
+    client = MetabaseClient()
+    mapping = client.fetch_map_and_terms([qid])
+    item = mapping.get(qid, {})
+    metabase_id = None
+    for lang_map in item.values():
+        metabase_id = lang_map.get('metabase_id')
+        if metabase_id:
+            break
+    if not metabase_id:
+        return Response({'detail': 'Metabase item not found for qid'}, status=status.HTTP_400_BAD_REQUEST)
+
+    client.login_bot()
+    changed = []
+    if label is not None:
+        client.set_term(metabase_id, lang, 'label', label, request.user.username)
+        changed.append('label')
+    if description is not None:
+        client.set_term(metabase_id, lang, 'description', description, request.user.username)
+        changed.append('description')
+
+    return Response({'status': 'ok', 'changed': changed, 'metabase_id': metabase_id})

--- a/translate/views_api.py
+++ b/translate/views_api.py
@@ -1,75 +1,92 @@
 from typing import List
 
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework import status, viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework import status
+from rest_framework.decorators import action
 
 from skills.models import Skill
 from .services import MetabaseClient, build_capacity_list
+from .serializers import CapacityItemSerializer, TranslationSubmitSerializer
+
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 
 
-@api_view(['GET'])
-@permission_classes([IsAuthenticated])
-def capacities_list(request):
-    """Return list of capacities with current and fallback terms for a given lang.
-    Query params:
-      - lang: required language code (e.g., 'pt-br')
-      - fallback: optional fallback language (default 'en')
-    """
-    lang = request.query_params.get('lang')
-    if not lang:
-        return Response({'detail': 'Missing lang parameter'}, status=status.HTTP_400_BAD_REQUEST)
-    fallback = request.query_params.get('fallback', 'en')
+class CapacityTranslationViewSet(viewsets.ViewSet):
+    permission_classes = [IsAuthenticated]
 
-    qids: List[str] = list(
-        Skill.objects.order_by('pk').values_list('skill_wikidata_item', flat=True)
+    @extend_schema(
+        summary='List capacity items with translations.',
+        description='This endpoint lists capacity items with their translations retrieved from Metabase.',
+        parameters=[
+            OpenApiParameter(
+                name='lang',
+                type=str,
+                description='Target language code (e.g., "fr" for French).',
+                required=True,
+            ),
+            OpenApiParameter(
+                name='fallback',
+                type=str,
+                description='Fallback language code (default: "en").',
+                required=False,
+            ),
+        ],
+        responses=CapacityItemSerializer,
     )
-    client = MetabaseClient()
-    terms = client.fetch_map_and_terms(qids)
-    items = build_capacity_list(terms, lang=lang, fallback=fallback)
-    # Sort by missing first to help translators
-    def is_missing(it):
-        return (not it.get('label')) or (not it.get('description'))
-    items.sort(key=lambda it: (not is_missing(it), (it.get('fallback_label') or '') .lower()))
-    return Response({'results': items})
+    def list(self, request):  # GET /capacities/?lang=xx&fallback=en
+        lang = request.query_params.get('lang')
+        if not lang:
+            return Response({'detail': 'Missing lang parameter'}, status=status.HTTP_400_BAD_REQUEST)
+        fallback = request.query_params.get('fallback', 'en')
 
+        qids: List[str] = list(
+            Skill.objects.order_by('pk').values_list('skill_wikidata_item', flat=True)
+        )
+        client = MetabaseClient()
+        terms = client.fetch_map_and_terms(qids)
+        items = build_capacity_list(terms, lang=lang, fallback=fallback)
 
-@api_view(['POST'])
-@permission_classes([IsAuthenticated])
-def submit_translation(request):
-    """Submit label/description for a given qid/lang using the bot.
-    Body (JSON): { qid: 'Q...', lang: 'xx', label?: str, description?: str }
-    """
-    payload = request.data or {}
-    qid = (payload.get('qid') or '').strip()
-    lang = (payload.get('lang') or '').strip()
-    label = payload.get('label')
-    description = payload.get('description')
+        def is_missing(it):
+            return (not it.get('label')) or (not it.get('description'))
 
-    if not qid or not lang or (label is None and description is None):
-        return Response({'detail': 'Missing qid, lang, or fields'}, status=status.HTTP_400_BAD_REQUEST)
-    if lang == 'en':
-        return Response({'detail': 'English (en) is the base language and cannot be edited.'}, status=status.HTTP_400_BAD_REQUEST)
+        items.sort(key=lambda it: (not is_missing(it), (it.get('fallback_label') or '').lower()))
+        serializer = CapacityItemSerializer(items, many=True)
+        return Response({'results': serializer.data})
 
-    client = MetabaseClient()
-    mapping = client.fetch_map_and_terms([qid])
-    item = mapping.get(qid, {})
-    metabase_id = None
-    for lang_map in item.values():
-        metabase_id = lang_map.get('metabase_id')
-        if metabase_id:
-            break
-    if not metabase_id:
-        return Response({'detail': 'Metabase item not found for qid'}, status=status.HTTP_400_BAD_REQUEST)
+    @extend_schema(
+        summary='Submit a translation for a capacity item.',
+        description='This endpoint allows submitting translations for capacity items to Metabase.',
+        request=TranslationSubmitSerializer,
+        responses={'200': {'type': 'object', 'properties': {'status': {'type': 'string'}, 'changed': {'type': 'array', 'items': {'type': 'string'}}, 'metabase_id': {'type': 'string'}}}},
+    )
+    def create(self, request):  # POST /capacities/
+        serializer = TranslationSubmitSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response({'detail': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+        qid = serializer.validated_data['qid']
+        lang = serializer.validated_data['lang']
+        label = serializer.validated_data.get('label')
+        description = serializer.validated_data.get('description')
 
-    client.login_bot()
-    changed = []
-    if label is not None:
-        client.set_term(metabase_id, lang, 'label', label, request.user.username)
-        changed.append('label')
-    if description is not None:
-        client.set_term(metabase_id, lang, 'description', description, request.user.username)
-        changed.append('description')
+        client = MetabaseClient()
+        mapping = client.fetch_map_and_terms([qid])
+        item = mapping.get(qid, {})
+        metabase_id = None
+        for lang_map in item.values():
+            metabase_id = lang_map.get('metabase_id')
+            if metabase_id:
+                break
+        if not metabase_id:
+            return Response({'detail': 'Metabase item not found for qid'}, status=status.HTTP_400_BAD_REQUEST)
 
-    return Response({'status': 'ok', 'changed': changed, 'metabase_id': metabase_id})
+        client.login_bot()
+        changed = []
+        if label is not None:
+            client.set_term(metabase_id, lang, 'label', label, request.user.username)
+            changed.append('label')
+        if description is not None:
+            client.set_term(metabase_id, lang, 'description', description, request.user.username)
+            changed.append('description')
+
+        return Response({'status': 'ok', 'changed': changed, 'metabase_id': metabase_id})

--- a/users/admin.py
+++ b/users/admin.py
@@ -11,7 +11,7 @@ class ProfileInline(admin.StackedInline):
 class AccountUserAdmin(AuthUserAdmin):
     list_display = ('username', 'is_staff', 'is_active')
     # Override default search_fields to remove first_name/last_name which are not present
-    search_fields = ('username')
+    search_fields = ['username']
     # Use a custom add form template to display a very prominent warning banner.
     add_form_template = 'admin/users/customuser/add_form.html'
 

--- a/users/admin.py
+++ b/users/admin.py
@@ -10,6 +10,8 @@ class ProfileInline(admin.StackedInline):
 
 class AccountUserAdmin(AuthUserAdmin):
     list_display = ('username', 'is_staff', 'is_active')
+    # Override default search_fields to remove first_name/last_name which are not present
+    search_fields = ('username')
     # Use a custom add form template to display a very prominent warning banner.
     add_form_template = 'admin/users/customuser/add_form.html'
 

--- a/users/serializers/saved_item_serializers.py
+++ b/users/serializers/saved_item_serializers.py
@@ -3,7 +3,9 @@ from orgs.models import Organization
 
 from users.models import SavedItem, CustomUser
 
+from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 
+@extend_schema_field(OpenApiTypes.INT)
 class EntityIdField(serializers.Field):
     @staticmethod
     def _get_user_id(instance):


### PR DESCRIPTION
This pull request introduces a new translation feature to the CapX platform, allowing users to view and submit translations for capacity items. It adds a new `translate` Django app with API endpoints, authentication views, and integration with Metabase (Wikibase) for fetching and updating translations. Additionally, there are minor improvements to admin and serializer code elsewhere.

**Translation feature integration:**

* Added the new `translate` app to `INSTALLED_APPS` in `settings.py` and registered its URLs and API endpoints in `urls.py`, enabling both web and API access for translation functionality. [[1]](diffhunk://#diff-6f9b02506e9090171d696773b3cca52c9ee9c89a1cd88bb5c4a4c97b5deee942R33) [[2]](diffhunk://#diff-8edd1b4845f1351f418bc895308fb2a14b0208379bc2097a85902a3dc0bfb6ffR36) [[3]](diffhunk://#diff-8edd1b4845f1351f418bc895308fb2a14b0208379bc2097a85902a3dc0bfb6ffR65-R70)
* Implemented the `MetabaseClient` service in `translate/services.py` to fetch and edit translation terms in Metabase, including authentication and SPARQL queries.
* Added serializers (`CapacityItemSerializer`, `TranslationSubmitSerializer`) for validating translation data and API requests in `translate/serializers.py`.
* Created `CapacityTranslationViewSet` in `translate/views_api.py` to provide authenticated API endpoints for listing capacity items with translations and submitting new translations.

**Web interface and authentication:**

* Added views and templates for the translation area, including login/logout and OAuth integration with MediaWiki, in `translate/views.py`, `translate/urls.py`, and `translate/templates/translate/login.html`. [[1]](diffhunk://#diff-2fd4bff7c7f356eca635750892afa4f8f91491442af7729dd3ec569083ea0ad6R1-R13) [[2]](diffhunk://#diff-9400d202a7cb1c68bdddf0ed127099acebd459e1c1b3270d5ebe8431779fe9c5R1-R63) [[3]](diffhunk://#diff-e737cb4c05addcedf10998c07b1a0cbc29ec713dee0c40b6709d33e0ec05819aR1-R15)

**General improvements:**

* Updated the API version in `settings.py` to `2.1.52`.
* Improved admin and serializer code in `users/admin.py` and `users/serializers/saved_item_serializers.py` for better search and schema documentation. [[1]](diffhunk://#diff-4e2a7c0761d592a2f711106f3f93948e625d6f53b53bd05fddd02648bb1c12a1R13-R14) [[2]](diffhunk://#diff-3fd6e008ab73f37a432eacf498f6c947e9d4602eaf0e461e6e6b661ca740841aR6-R8)