### PR TITLE
Locks users based on Global User ID instead of usernames

### DIFF
--- a/CapX/useragent.py
+++ b/CapX/useragent.py
@@ -1,0 +1,14 @@
+"""Global User-Agent utility for outbound HTTP requests.
+
+Provides a consistent User-Agent string across management commands and
+service modules. Format: "CapacityExchange/<version>" optionally with
+an extra component suffix: "CapacityExchange/<version> (<extra>)".
+"""
+from django.conf import settings
+
+def get_user_agent(extra: str | None = None) -> str:
+    version = getattr(settings, "SPECTACULAR_SETTINGS", {}).get("VERSION", "dev")
+    base = f"CapacityExchange/{version}"
+    if extra:
+        return f"{base} ({extra})"
+    return base

--- a/portal/views.py
+++ b/portal/views.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from .models import Partner, PartnerMembership
 from social_django.utils import load_strategy, load_backend
 from users.models import AuthExtraInfo
+from CapX.useragent import get_user_agent
 from django.views.decorators.http import require_GET, require_POST
 from users.models import CustomUser, Profile, UserBadge, Badge
 from knox.models import AuthToken
@@ -103,7 +104,7 @@ def dashboard(request):
             resp = requests.get(
                 'https://metabase.wikibase.cloud/query/sparql',
                 params={'query': query, 'format': 'json'},
-                headers={'User-Agent': 'CapX-Portal/1.0'}
+                headers={'User-Agent': get_user_agent('Portal')}
             )
             data = resp.json()
             mapping = {}

--- a/translate/services.py
+++ b/translate/services.py
@@ -5,10 +5,11 @@ from typing import Dict, Optional
 
 import requests
 from django.conf import settings
+from CapX.useragent import get_user_agent
 
 METABASE_API_ENDPOINT = "https://metabase.wikibase.cloud/w/api.php"
 METABASE_SPARQL_ENDPOINT = "https://metabase.wikibase.cloud/query/sparql"
-USER_AGENT = "CapX/Translate/1.0"
+USER_AGENT = get_user_agent("Translate")
 
 
 class MetabaseClient:

--- a/users/management/commands/export.py
+++ b/users/management/commands/export.py
@@ -2,8 +2,8 @@ from django.core.management.base import BaseCommand
 from users.serializers import ProfileSerializer
 from users.models import Profile, DataHash
 from skills.models import Skill
-from django.conf import settings
 from users.models import CustomUser, UserBadge
+from CapX.useragent import get_user_agent
 import json
 import requests
 import hashlib
@@ -24,9 +24,6 @@ class Command(BaseCommand):
             return item.replace(',', '&#44;') if isinstance(item, str) else item
         return '[' + ', '.join(str(escape_commas(item)) for item in data_list) + ']'
 
-    def get_user_agent(self):
-        version = getattr(settings, "SPECTACULAR_SETTINGS", {}).get("VERSION", "dev")
-        return f"CapacityExchangeBot/{version}"
 
     def get_meta_wiki_users(self):
         query_params = {
@@ -42,7 +39,7 @@ class Command(BaseCommand):
         response = requests.get(
             'https://meta.wikimedia.org/w/api.php',
             params=query_params,
-            headers={'User-Agent': self.get_user_agent()}
+            headers={'User-Agent': get_user_agent('Export')}
         )
         if self.verbosity >= 2:
             self.stdout.write(f"Meta wiki users response: {response.json()}")
@@ -202,7 +199,7 @@ class Command(BaseCommand):
             GROUP BY ?item ?value ?language
             ORDER BY ?language
             """
-        headers = {'User-Agent': self.get_user_agent(), 'Accept': 'application/sparql-results+json'}
+        headers = {'User-Agent': get_user_agent('Export'), 'Accept': 'application/sparql-results+json'}
         response = requests.get(
             'https://metabase.wikibase.cloud/query/sparql',
             params={'query': query},
@@ -322,7 +319,7 @@ class Command(BaseCommand):
             "type": "login",
             "format": "json"
         }
-        response = session.get(url=url, params=params, headers={'User-Agent': self.get_user_agent()})
+        response = session.get(url=url, params=params, headers={'User-Agent': get_user_agent('Export')})
         data = response.json()
         if self.verbosity >= 2:
             self.stdout.write(f"Login token response: {data}")
@@ -336,7 +333,7 @@ class Command(BaseCommand):
             "lgtoken": login_token,
             "format": "json"
         }
-        response = session.post(url, data=params, headers={'User-Agent': self.get_user_agent()}).json()
+        response = session.post(url, data=params, headers={'User-Agent': get_user_agent('Export')}).json()
         if response['login']['result'] != 'Success':
             raise requests.exceptions.RequestException("Login failed")
         if self.verbosity >= 2:
@@ -349,7 +346,7 @@ class Command(BaseCommand):
             "meta": "tokens",
             "format": "json"
         }
-        response = session.get(url=url, params=params, headers={'User-Agent': self.get_user_agent()})
+        response = session.get(url=url, params=params, headers={'User-Agent': get_user_agent('Export')})
         data = response.json()
         if self.verbosity >= 2:
             self.stdout.write(f"CSRF token response: {data}")
@@ -368,7 +365,7 @@ class Command(BaseCommand):
         if self.verbosity >= 2:
             self.stdout.write(f"Editing page {title} with text: {text}")
         
-        response = session.post(url, data=params, headers={'User-Agent': self.get_user_agent()})
+        response = session.post(url, data=params, headers={'User-Agent': get_user_agent('Export')})
         return response.json()
 
     def hash_data(self, data):

--- a/users/management/commands/export.py
+++ b/users/management/commands/export.py
@@ -4,6 +4,7 @@ from users.models import Profile, DataHash
 from skills.models import Skill
 from users.models import CustomUser, UserBadge
 from CapX.useragent import get_user_agent
+from django.conf import settings
 import json
 import requests
 import hashlib

--- a/users/management/commands/locks.py
+++ b/users/management/commands/locks.py
@@ -1,42 +1,63 @@
 from django.core.management.base import BaseCommand
 from users.models import CustomUser
-from django.conf import settings
 import requests
 from social_django.models import UserSocialAuth
+from CapX.useragent import get_user_agent
 
 class Command(BaseCommand):
     help = 'Check if Wikimedia usernames are locked and deactivate them locally'
 
-    def get_user_agent(self):
-        version = getattr(settings, "SPECTACULAR_SETTINGS", {}).get("VERSION", "dev")
-        return f"CapacityExchangeBot/{version}"
+    def fetch_user_info(self, mediawiki_auth):
+        params = {
+            'action': 'query',
+            'meta': 'globaluserinfo',
+            'guiid': mediawiki_auth.uid if mediawiki_auth else '',
+            'format': 'json',
+            'formatversion': '2',
+        }
+        response = requests.get(
+            'https://meta.wikimedia.org/w/api.php',
+            params=params,
+            headers={'User-Agent': get_user_agent('Locks')}
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data.get('query', {}).get('globaluserinfo', {})
+
+    def rename_user_if_needed(self, user, remote_name):
+        if not remote_name or remote_name == user.username:
+            return
+        # Collision check including inactive users
+        if CustomUser.all_objects.filter(username=remote_name).exclude(pk=user.pk).exists():
+            if self.verbosity >= 1:
+                self.stdout.write(self.style.WARNING(
+                    f'Cannot rename {user.username} -> {remote_name}: username already exists locally.'
+                ))
+            return
+        old_username = user.username
+        user.username = remote_name
+        user.save(update_fields=['username'])
+        if self.verbosity >= 2:
+            self.stdout.write(self.style.SUCCESS(f'Renamed local user {old_username} -> {remote_name}'))
+
+    def deactivate_if_locked(self, user, user_info):
+        if user_info.get('locked') and user.is_active:
+            user.is_active = False
+            user.save(update_fields=['is_active'])
+            if self.verbosity >= 2:
+                self.stdout.write(self.style.SUCCESS(f'User {user.username} is locked and has been deactivated.'))
+        elif self.verbosity >= 2:
+            notice_style = getattr(self.style, 'NOTICE', self.style.WARNING)
+            self.stdout.write(notice_style(f'User {user.username} is not locked.'))
 
     def handle(self, *args, **options):
         self.verbosity = options.get('verbosity', 1)
-        users = CustomUser.objects.all()
-        for user in users:
-            params = {
-                'action': 'query',
-                'meta': 'globaluserinfo',
-                'guiid': UserSocialAuth.objects.filter(user=user, provider='mediawiki').first().uid if UserSocialAuth.objects.filter(user=user, provider='mediawiki').exists() else '',
-                'format': 'json',
-                'formatversion': '2',
-            }
-
+        for user in CustomUser.objects.all():
+            mediawiki_auth = UserSocialAuth.objects.filter(user=user, provider='mediawiki').first()
             try:
-                response = requests.get('https://meta.wikimedia.org/w/api.php', params=params, headers={'User-Agent': self.get_user_agent()})
-                response.raise_for_status()  # Raise an error for bad responses
+                user_info = self.fetch_user_info(mediawiki_auth)
             except Exception as e:
                 self.stdout.write(self.style.ERROR(f'Error fetching data for user {user.username}: {e}'))
                 continue
-            
-            data = response.json()
-            user_info = data['query']['globaluserinfo']
-            if 'locked' in user_info and user_info['locked']:
-                user.is_active = False
-                user.save()
-                if self.verbosity >= 2:
-                    self.stdout.write(self.style.SUCCESS(f'User {user.username} is locked and has been deactivated.'))
-            else:
-                if self.verbosity >= 2:
-                    self.stdout.write(self.style.NOTICE(f'User {user.username} is not locked.'))
+            self.rename_user_if_needed(user, user_info.get('name'))
+            self.deactivate_if_locked(user, user_info)

--- a/users/management/commands/locks.py
+++ b/users/management/commands/locks.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 from users.models import CustomUser
 from django.conf import settings
 import requests
+from social_django.models import UserSocialAuth
 
 class Command(BaseCommand):
     help = 'Check if Wikimedia usernames are locked and deactivate them locally'
@@ -17,7 +18,7 @@ class Command(BaseCommand):
             params = {
                 'action': 'query',
                 'meta': 'globaluserinfo',
-                'guiuser': user.username,
+                'guiid': UserSocialAuth.objects.filter(user=user, provider='mediawiki').first().uid if UserSocialAuth.objects.filter(user=user, provider='mediawiki').exists() else '',
                 'format': 'json',
                 'formatversion': '2',
             }

--- a/users/management/commands/sync_translations.py
+++ b/users/management/commands/sync_translations.py
@@ -16,7 +16,8 @@ METABASE_API_ENDPOINT = "https://metabase.wikibase.cloud/w/api.php"
 METABASE_SPARQL_ENDPOINT = "https://metabase.wikibase.cloud/query/sparql"
 METAWIKI_API_ENDPOINT = "https://meta.wikimedia.org/w/api.php"
 
-USER_AGENT = "CapX/1.0"
+from CapX.useragent import get_user_agent
+USER_AGENT = get_user_agent("SyncTranslations")
 
 class Command(BaseCommand):
     help = (


### PR DESCRIPTION
This pull request updates the `users/management/commands/locks.py` management command to improve how it checks Wikimedia usernames for locked status. The main change is switching from using the username to the Global User ID when querying the Wikimedia API, which should make the lock-checking process more reliable by avoiding users renaming' shenanigans.

Integration with social authentication:

* Imported `UserSocialAuth` from `social_django.models` to access linked Wikimedia user IDs for each user.

API query logic improvement:

* Updated the API request parameters to use the `guiid` field (Wikimedia user ID from `UserSocialAuth.uid`) instead of the local username, improving accuracy when checking lock status.