### PR TITLE
Add DRF Spectacular schema extensions for mentorship

### DIFF
--- a/CapX/settings.py
+++ b/CapX/settings.py
@@ -169,7 +169,7 @@ REST_KNOX = {'TOKEN_TTL': timedelta(days=30)}
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Capacity Exchange (CapX) API',
     'DESCRIPTION': 'The Capacity Exchange (CapX) is a platform for finding and connecting with fellow Wikimedians to exchange knowledge, skills, and services on a global level.',
-    'VERSION': '2.2.12',
+    'VERSION': '2.2.13',
     'SERVE_INCLUDE_SCHEMA': True,
     'SWAGGER_UI_DIST': 'SIDECAR',
     'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',

--- a/portal/views_api.py
+++ b/portal/views_api.py
@@ -15,21 +15,56 @@ from portal.serializers import (
     PartnerMentorshipFormMenteeResponseSerializer,
 )
 
+from drf_spectacular.utils import extend_schema_view, extend_schema
+
+@extend_schema_view(
+    list=extend_schema(
+        summary='List mentorship availabilities.',
+        description='This endpoint lists all partners that have the mentorship program available.',
+    ),
+    retrieve=extend_schema(
+        summary='Retrieve mentorship availability by ID.',
+        description='This endpoint retrieves a mentorship availability by its ID.',
+    ),
+)
 class PartnerMentorshipAvailabilityViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = PartnerMentorshipAvailability.objects.select_related('partner__organization').order_by('-updated_at')
     serializer_class = PartnerMentorshipAvailabilitySerializer
 
-
+@extend_schema_view(
+    list=extend_schema(
+        summary='List mentorship forms for mentors.',
+        description='This endpoint lists all mentorship forms for mentors.',
+    ),
+    retrieve=extend_schema(
+        summary='Retrieve mentorship form for mentors by ID.',
+        description='This endpoint retrieves a mentorship form for mentors by its ID.',
+    ),
+)
 class PartnerMentorshipFormMentorViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = PartnerMentorshipFormMentor.objects.select_related('partner__organization').order_by('-created_at')
     serializer_class = PartnerMentorshipFormMentorSerializer
 
-
+@extend_schema_view(
+    list=extend_schema(
+        summary='List mentorship forms for mentees.',
+        description='This endpoint lists all mentorship forms for mentees.',
+    ),
+    retrieve=extend_schema(
+        summary='Retrieve mentorship form for mentees by ID.',
+        description='This endpoint retrieves a mentorship form for mentees by its ID.',
+    ),
+)
 class PartnerMentorshipFormMenteeViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = PartnerMentorshipFormMentee.objects.select_related('partner__organization').order_by('-created_at')
     serializer_class = PartnerMentorshipFormMenteeSerializer
 
-
+@extend_schema_view(
+    create=extend_schema(
+        summary='Submit a mentorship form response for mentors.',
+        description='This endpoint allows authenticated users to submit a mentorship form response for mentors.',
+    ),
+)
 class PartnerMentorshipFormMentorResponseViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     queryset = PartnerMentorshipFormMentorResponse.objects.select_related(
         'form',
@@ -39,7 +74,12 @@ class PartnerMentorshipFormMentorResponseViewSet(mixins.CreateModelMixin, viewse
     http_method_names = ['post']
     permission_classes = [permissions.IsAuthenticated]
 
-
+@extend_schema_view(
+    create=extend_schema(
+        summary='Submit a mentorship form response for mentees.',
+        description='This endpoint allows authenticated users to submit a mentorship form response for mentees.',
+    ),
+)
 class PartnerMentorshipFormMenteeResponseViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     queryset = PartnerMentorshipFormMenteeResponse.objects.select_related(
         'form',

--- a/skills/views.py
+++ b/skills/views.py
@@ -117,7 +117,16 @@ class SkillByTypeViewSet(viewsets.ReadOnlyModelViewSet):
         response = {'message': 'Please provide a skill_id to retrieve skills.'}
         return Response(response, status=status.HTTP_400_BAD_REQUEST)
 
-
+@extend_schema_view(
+    list=extend_schema(
+        summary='List all hashtags.',
+        description='This endpoint lists all hashtags.',
+    ),
+    retrieve=extend_schema(
+        summary='Retrieve a hashtag by ID.',
+        description='This endpoint retrieves a hashtag by its ID.',
+    ),
+)
 class HashtagViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Hashtag.objects.all()
     serializer_class = HashtagSerializer


### PR DESCRIPTION
This pull request primarily adds detailed API documentation for several viewsets using `drf_spectacular` decorators, improving the clarity and usability of the API endpoints. Additionally, it updates the API version in the settings.

API documentation enhancements:

* Added `@extend_schema_view` and `@extend_schema` decorators to the mentorship-related viewsets in `portal/views_api.py`, providing summaries and descriptions for list, retrieve, and create endpoints. This includes `PartnerMentorshipAvailabilityViewSet`, `PartnerMentorshipFormMentorViewSet`, `PartnerMentorshipFormMenteeViewSet`, `PartnerMentorshipFormMentorResponseViewSet`, and `PartnerMentorshipFormMenteeResponseViewSet`. [[1]](diffhunk://#diff-2c124e425e5f177eeddae389e34aa7d16a51a2f6d6b5bca633a06ab45deff164R18-R67) [[2]](diffhunk://#diff-2c124e425e5f177eeddae389e34aa7d16a51a2f6d6b5bca633a06ab45deff164L42-R82)
* Added similar documentation for the `HashtagViewSet` in `skills/views.py`, including endpoint summaries and descriptions for listing and retrieving hashtags.

Version update:

* Updated the API version in `CapX/settings.py` from `2.2.12` to `2.2.13`.