### PR TITLE
Add display_priority ordering to users endpoint for Explore feed

### DIFF
--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
 from users.models import Profile, CustomUser, LanguageProficiency, SavedItem, Badge, UserBadge
-from users.models import Territory, Language, WikimediaProject
+from users.models import Territory, Language, WikimediaProject, Avatar
 from users.serializers import ProfileSerializer, TerritorySerializer, LanguageSerializer, WikimediaProjectSerializer, SavedItemSerializer, BadgeSerializer, UserBadgeSerializer
 from skills.models import Skill
 from orgs.models import Organization, OrganizationType, OrganizationName
@@ -1122,6 +1122,77 @@ class UsersOrderingTestCase(TestCase):
         self.assertGreaterEqual(len(results), 3)
         # user3 should be first as it was updated most recently
         self.assertEqual(results[0]['user']['username'], 'gamma_user')
+
+
+class UsersDisplayPriorityOrderingTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.skill = Skill.objects.create(skill_wikidata_item='Q123456789')
+        self.avatar = Avatar.objects.create(avatar_url='https://example.org/avatar.png')
+
+    def _make_profile(self, username, *, has_skill=False, avatar=False, wikidata=False):
+        user = CustomUser.objects.create_user(username=username, password=str(secrets.randbits(16)))
+        profile = user.profile
+        if avatar:
+            profile.avatar = self.avatar
+        if wikidata:
+            profile.wikidata_qid = 'Q42'
+        profile.save()
+        if has_skill:
+            profile.skills_known.add(self.skill)
+        return user
+
+    def test_display_priority_orders_complete_and_image_tiers(self):
+        # Created out of priority order on purpose to prove ordering is by display_priority.
+        self._make_profile('p5_incomplete_noimage')
+        self._make_profile('p2_complete_noimage', has_skill=True)
+        self._make_profile('p4_incomplete_avatar', avatar=True)
+        self._make_profile('p0_complete_wikidata', has_skill=True, wikidata=True)
+        self._make_profile('p3_incomplete_wikidata', wikidata=True)
+        self._make_profile('p1_complete_avatar', has_skill=True, avatar=True)
+
+        response = self.client.get('/users/?ordering=display_priority,-last_update')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        usernames = [r['user']['username'] for r in response.data['results']]
+        self.assertEqual(
+            usernames,
+            [
+                'p0_complete_wikidata',
+                'p1_complete_avatar',
+                'p2_complete_noimage',
+                'p3_incomplete_wikidata',
+                'p4_incomplete_avatar',
+                'p5_incomplete_noimage',
+            ],
+        )
+
+    def test_display_priority_avatar_wins_over_wikidata(self):
+        # A chosen avatar takes precedence over a linked Wikidata image (mirrors the UI).
+        self._make_profile('with_avatar_and_wikidata', has_skill=True, avatar=True, wikidata=True)
+        self._make_profile('with_wikidata_only', has_skill=True, wikidata=True)
+
+        response = self.client.get('/users/?ordering=display_priority,-last_update')
+        usernames = [r['user']['username'] for r in response.data['results']]
+        # Wikidata-image profile (priority 0) ranks before the avatar one (priority 1).
+        self.assertLess(
+            usernames.index('with_wikidata_only'),
+            usernames.index('with_avatar_and_wikidata'),
+        )
+
+    def test_display_priority_breaks_ties_by_last_update(self):
+        # Same tier (complete + no image): most recently updated comes first.
+        older = self._make_profile('older_complete', has_skill=True)
+        newer = self._make_profile('newer_complete', has_skill=True)
+        # Touch `older` last so it would win by recency if the tie-break is wrong-way,
+        # then touch `newer` to make it the most recent.
+        older.profile.about = 'touch older'
+        older.profile.save()
+        newer.profile.about = 'touch newer'
+        newer.profile.save()
+
+        response = self.client.get('/users/?ordering=display_priority,-last_update')
+        usernames = [r['user']['username'] for r in response.data['results']]
+        self.assertLess(usernames.index('newer_complete'), usernames.index('older_complete'))
 
 
 class LanguagesByTerritoryViewTestCase(TestCase):

--- a/users/views/account.py
+++ b/users/views/account.py
@@ -53,7 +53,14 @@ from users.serializers import ProfileSerializer
             ),
             OpenApiParameter(
                 name='ordering',
-                description='Sort users by field. Prefix with "-" for descending order. Options: last_update.',
+                description=(
+                    'Sort users by field. Prefix with "-" for descending order. '
+                    'Options: last_update, display_priority. '
+                    'display_priority ranks profiles for the Explore feed: complete profiles '
+                    '(with capacities) before incomplete ones, and within each group those with '
+                    'a Wikidata image first, then a chosen avatar, then no image. Combine with '
+                    'last_update as a tie-breaker, e.g. "display_priority,-last_update".'
+                ),
                 required=False,
                 type=OpenApiTypes.STR,
             ),
@@ -68,7 +75,7 @@ class UsersViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ProfileSerializer
     queryset = Profile.objects.all()
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
-    ordering_fields = ['last_update']
+    ordering_fields = ['last_update', 'display_priority']
     filterset_fields = [
         'user__username',
         'about',
@@ -83,6 +90,36 @@ class UsersViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         queryset = super().get_queryset()
+
+        # Annotate a display priority used by the Explore feed ordering.
+        # A profile "has an image" via Wikidata when it links a Wikidata item but
+        # picked no avatar (avatar is null); a chosen avatar always wins over Wikidata.
+        # Completeness (having any capacity) takes precedence over the image tier, so
+        # incomplete profiles always rank after complete ones:
+        #   complete:   wikidata image = 0, chosen avatar = 1, no image = 2
+        #   incomplete: wikidata image = 3, chosen avatar = 4, no image = 5
+        # Using Exists keeps the skill check from multiplying rows across the M2M joins.
+        has_any_skill = models.Exists(
+            Profile.all_objects.filter(pk=models.OuterRef('pk')).filter(
+                models.Q(skills_known__isnull=False)
+                | models.Q(skills_available__isnull=False)
+                | models.Q(skills_wanted__isnull=False)
+            )
+        )
+        has_wikidata_image = models.Q(avatar__isnull=True) & ~models.Q(wikidata_qid='')
+        has_avatar = models.Q(avatar__isnull=False)
+        queryset = queryset.annotate(_has_any_skill=has_any_skill).annotate(
+            display_priority=models.Case(
+                models.When(models.Q(_has_any_skill=True) & has_wikidata_image, then=models.Value(0)),
+                models.When(models.Q(_has_any_skill=True) & has_avatar, then=models.Value(1)),
+                models.When(_has_any_skill=True, then=models.Value(2)),
+                models.When(has_wikidata_image, then=models.Value(3)),
+                models.When(has_avatar, then=models.Value(4)),
+                default=models.Value(5),
+                output_field=models.IntegerField(),
+            )
+        )
+
         has_skills_known = self.request.query_params.get('has_skills_known')
         has_skills_available = self.request.query_params.get('has_skills_available')
         has_skills_wanted = self.request.query_params.get('has_skills_wanted')


### PR DESCRIPTION
Annotate profiles with a display_priority that ranks complete profiles (with capacities) before incomplete ones, sub-ranked by image tier (Wikidata image, chosen avatar, none). Expose it as an ordering field so the feed can request display_priority,-last_update, and cover it with tests.